### PR TITLE
Add Support for Travis-Based Build Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: cpp
+
+compiler:
+  - gcc
+
+addons:
+  apt:
+    sources:
+      - boost-latest
+      - ubuntu-toolchain-r-test
+    packages:
+      - libboost1.55-all-dev
+      - gcc-4.8
+      - g++-4.8
+
+install:
+    - export CXX="g++-4.8" CC="gcc-4.8"
+    - cd ..
+
+    - git clone https://github.com/OPM/opm-common.git
+
+    - opm-common/travis/build-opm-common.sh
+
+script: opm-flowdiagnostics/travis/build-and-test-opm-flowdiagnostics.sh

--- a/opm/flowdiagnostics/reorder/tarjan.c
+++ b/opm/flowdiagnostics/reorder/tarjan.c
@@ -21,15 +21,11 @@ SOFTWARE.
 */
 
 #include "config.h"
+
+#include <opm/flowdiagnostics/reorder/tarjan.h>
+
 #include <assert.h>
 #include <stddef.h>
-
-#ifdef MATLAB_MEX_FILE
-#include "tarjan.h"
-#else
-#include <opm/flowdiagnostics/reorder/tarjan.h>
-#endif
-
 
 static void
 clear_vector(size_t n, int *v)

--- a/travis/build-and-test-opm-flowdiagnostics.sh
+++ b/travis/build-and-test-opm-flowdiagnostics.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+
+sh ./opm-flowdiagnostics/travis/build-opm-flowdiagnostics.sh
+
+(cd opm-flowdiagnostics/build
+ ctest --output-on-failure)

--- a/travis/build-opm-common-shared.sh
+++ b/travis/build-opm-common-shared.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -e
+
+mkdir -p opm-flowdiagnostics/build
+
+(cd opm-flowdiagnostics/build
+ cmake ../ -DBUILD_SHARED_LIBS=ON
+
+ make)

--- a/travis/build-opm-flowdiagnostics.sh
+++ b/travis/build-opm-flowdiagnostics.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -e
+
+mkdir -p opm-flowdiagnostics/build
+
+(cd opm-flowdiagnostics/build
+ cmake ../
+
+ make)


### PR DESCRIPTION
Inspired by similar setups in other OPM modules.

While here, also switch to using OMP's canonical order of include statements.  The interface file goes first (after `config.h`).
