### PR TITLE
Add Interface Layer for Flow Diagnostics Kernels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Editor autosave files
+*~
+*.swp
+
 # Compiled Object files
 *.slo
 *.lo
@@ -26,3 +30,9 @@
 *.exe
 *.out
 *.app
+
+# Mac OS X debug info
+*.dSYM
+
+# emacs directory setting:
+.dir-locals.el

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -61,5 +61,4 @@ list (APPEND PROGRAM_SOURCE_FILES
 # originally generated with the command:
 # find opm -name '*.h*' -a ! -name '*-pch.hpp' -printf '\t%p\n' | sort
 list (APPEND PUBLIC_HEADER_FILES
-	opm/flowdiagnostics/reorder/tarjan.h
 	)

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -26,16 +26,19 @@
 list (APPEND MAIN_SOURCE_FILES
 	opm/flowdiagnostics/CellSet.cpp
 	opm/flowdiagnostics/CellSetValues.cpp
+	opm/flowdiagnostics/ConnectionValues.cpp
 	opm/flowdiagnostics/reorder/tarjan.c
 	)
 
 list (APPEND TEST_SOURCE_FILES
 	tests/test_cellset.cpp
 	tests/test_cellsetvalues.cpp
+	tests/test_connectionvalues.cpp
 	tests/test_tarjan.cpp
 	)
 
 list (APPEND PUBLIC_HEADER_FILES
 	opm/flowdiagnostics/CellSet.hpp
 	opm/flowdiagnostics/CellSetValues.hpp
+	opm/flowdiagnostics/ConnectionValues.hpp
 	)

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -27,6 +27,7 @@ list (APPEND MAIN_SOURCE_FILES
 	opm/flowdiagnostics/CellSet.cpp
 	opm/flowdiagnostics/CellSetValues.cpp
 	opm/flowdiagnostics/ConnectionValues.cpp
+	opm/flowdiagnostics/ConnectivityGraph.cpp
 	opm/flowdiagnostics/reorder/tarjan.c
 	)
 
@@ -34,6 +35,7 @@ list (APPEND TEST_SOURCE_FILES
 	tests/test_cellset.cpp
 	tests/test_cellsetvalues.cpp
 	tests/test_connectionvalues.cpp
+	tests/test_connectivitygraph.cpp
 	tests/test_tarjan.cpp
 	)
 
@@ -41,4 +43,5 @@ list (APPEND PUBLIC_HEADER_FILES
 	opm/flowdiagnostics/CellSet.hpp
 	opm/flowdiagnostics/CellSetValues.hpp
 	opm/flowdiagnostics/ConnectionValues.hpp
+	opm/flowdiagnostics/ConnectivityGraph.hpp
 	)

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -25,14 +25,17 @@
 
 list (APPEND MAIN_SOURCE_FILES
 	opm/flowdiagnostics/CellSet.cpp
+	opm/flowdiagnostics/CellSetValues.cpp
 	opm/flowdiagnostics/reorder/tarjan.c
 	)
 
 list (APPEND TEST_SOURCE_FILES
 	tests/test_cellset.cpp
+	tests/test_cellsetvalues.cpp
 	tests/test_tarjan.cpp
 	)
 
 list (APPEND PUBLIC_HEADER_FILES
 	opm/flowdiagnostics/CellSet.hpp
+	opm/flowdiagnostics/CellSetValues.hpp
 	)

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -28,6 +28,7 @@ list (APPEND MAIN_SOURCE_FILES
 	opm/flowdiagnostics/CellSetValues.cpp
 	opm/flowdiagnostics/ConnectionValues.cpp
 	opm/flowdiagnostics/ConnectivityGraph.cpp
+	opm/flowdiagnostics/FlowDiagnosticsTool.cpp
 	opm/flowdiagnostics/reorder/tarjan.c
 	opm/flowdiagnostics/utility/RandomVector.cpp
 	)
@@ -37,6 +38,7 @@ list (APPEND TEST_SOURCE_FILES
 	tests/test_cellsetvalues.cpp
 	tests/test_connectionvalues.cpp
 	tests/test_connectivitygraph.cpp
+	tests/test_flowdiagnosticstool.cpp
 	tests/test_tarjan.cpp
 	)
 
@@ -45,5 +47,6 @@ list (APPEND PUBLIC_HEADER_FILES
 	opm/flowdiagnostics/CellSetValues.hpp
 	opm/flowdiagnostics/ConnectionValues.hpp
 	opm/flowdiagnostics/ConnectivityGraph.hpp
+	opm/flowdiagnostics/FlowDiagnosticsTool.hpp
 	opm/flowdiagnostics/utility/RandomVector.hpp
 	)

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -22,43 +22,14 @@
 #                             files can of course include other files than these;
 #                             you should only add to this list if the *user* of
 #                             the library needs it.
-#
-# ATTIC_FILES           Unmaintained files. This for the projects developers
-#                       only. Don't expect these files to build.
 
-# originally generated with the command:
-# find opm -name '*.c*' -printf '\t%p\n' | sort
 list (APPEND MAIN_SOURCE_FILES
 	opm/flowdiagnostics/reorder/tarjan.c
 	)
 
-# originally generated with the command:
-# find tests -name '*.cpp' -a ! -wholename '*/not-unit/*' -printf '\t%p\n' | sort
 list (APPEND TEST_SOURCE_FILES
 	tests/test_tarjan.cpp
 	)
 
-# originally generated with the command:
-# find tests -name '*.xml' -a ! -wholename '*/not-unit/*' -printf '\t%p\n' | sort
-list (APPEND TEST_DATA_FILES
-	)
-
-# originally generated with the command:
-# find tutorials examples -name '*.c*' -printf '\t%p\n' | sort
-list (APPEND EXAMPLE_SOURCE_FILES
-	)
-
-# originally generated with the command:
-# find attic -name '*.c*' -printf '\t%p\n' | sort
-list (APPEND ATTIC_FILES
-	)
-
-# programs listed here will not only be compiled, but also marked for
-# installation
-list (APPEND PROGRAM_SOURCE_FILES
-	)
-
-# originally generated with the command:
-# find opm -name '*.h*' -a ! -name '*-pch.hpp' -printf '\t%p\n' | sort
 list (APPEND PUBLIC_HEADER_FILES
 	)

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -29,6 +29,7 @@ list (APPEND MAIN_SOURCE_FILES
 	opm/flowdiagnostics/ConnectionValues.cpp
 	opm/flowdiagnostics/ConnectivityGraph.cpp
 	opm/flowdiagnostics/reorder/tarjan.c
+	opm/flowdiagnostics/utility/RandomVector.cpp
 	)
 
 list (APPEND TEST_SOURCE_FILES
@@ -44,4 +45,5 @@ list (APPEND PUBLIC_HEADER_FILES
 	opm/flowdiagnostics/CellSetValues.hpp
 	opm/flowdiagnostics/ConnectionValues.hpp
 	opm/flowdiagnostics/ConnectivityGraph.hpp
+	opm/flowdiagnostics/utility/RandomVector.hpp
 	)

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -24,12 +24,15 @@
 #                             the library needs it.
 
 list (APPEND MAIN_SOURCE_FILES
+	opm/flowdiagnostics/CellSet.cpp
 	opm/flowdiagnostics/reorder/tarjan.c
 	)
 
 list (APPEND TEST_SOURCE_FILES
+	tests/test_cellset.cpp
 	tests/test_tarjan.cpp
 	)
 
 list (APPEND PUBLIC_HEADER_FILES
+	opm/flowdiagnostics/CellSet.hpp
 	)

--- a/opm/flowdiagnostics/CellSet.cpp
+++ b/opm/flowdiagnostics/CellSet.cpp
@@ -1,0 +1,73 @@
+/*
+  Copyright 2016 SINTEF ICT, Applied Mathematics.
+  Copyright 2016 Statoil ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif // HAVE_CONFIG_H
+
+#include <opm/flowdiagnostics/CellSet.hpp>
+
+#include <utility>
+
+Opm::CellSetID::CellSetID()
+{}
+
+Opm::CellSetID::CellSetID(Repr id)
+    : id_(std::move(id))
+{
+}
+
+std::string
+Opm::CellSetID::to_string() const
+{
+    return id_;
+}
+
+// =====================================================================
+
+void
+Opm::CellSet::identify(CellSetID id)
+{
+    id_ = std::move(id);
+}
+
+const Opm::CellSetID&
+Opm::CellSet::id() const
+{
+    return id_;
+}
+
+void
+Opm::CellSet::insert(const int i)
+{
+    iset_.insert(i);
+}
+
+Opm::CellSet::const_iterator
+Opm::CellSet::begin() const
+{
+    return iset_.begin();
+}
+
+Opm::CellSet::const_iterator
+Opm::CellSet::end() const
+{
+    return iset_.end();
+}

--- a/opm/flowdiagnostics/CellSet.hpp
+++ b/opm/flowdiagnostics/CellSet.hpp
@@ -1,0 +1,67 @@
+/*
+  Copyright 2016 Statoil ASA.
+  Copyright 2016 SINTEF ICT, Applied Mathematics.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_CELLSET_HEADER_INCLUDED
+#define OPM_CELLSET_HEADER_INCLUDED
+
+#include <string>
+#include <unordered_set>
+
+namespace Opm
+{
+    class CellSetID
+    {
+    public:
+        using Repr = std::string;
+
+        CellSetID();
+
+        explicit CellSetID(Repr id);
+
+        std::string to_string() const;
+
+    private:
+        Repr id_;
+    };
+
+    class CellSet
+    {
+    private:
+        using IndexSet = std::unordered_set<int>;
+
+    public:
+        using const_iterator = IndexSet::const_iterator;
+
+        void identify(CellSetID id);
+
+        const CellSetID& id() const;
+
+        void insert(const int cell);
+
+        const_iterator begin() const;
+        const_iterator end()   const;
+
+    private:
+        CellSetID id_;
+        IndexSet  iset_;
+    };
+} // namespace Opm
+
+#endif  // OPM_CELLSET_HEADER_INCLUDED

--- a/opm/flowdiagnostics/CellSetValues.cpp
+++ b/opm/flowdiagnostics/CellSetValues.cpp
@@ -1,0 +1,54 @@
+/*
+  Copyright 2016 SINTEF ICT, Applied Mathematics.
+  Copyright 2016 Statoil ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif // HAVE_CONFIG_H
+
+#include <opm/flowdiagnostics/CellSetValues.hpp>
+
+#include <cassert>
+#include <utility>
+
+Opm::CellSetValues::CellSetValues(const SizeType initialCapacity)
+{
+    assoc_.reserve(initialCapacity);
+}
+
+void
+Opm::CellSetValues::addCellValue(const int    cellIndex,
+                                 const double cellValue)
+{
+    assoc_.push_back(Association{cellIndex, cellValue});
+}
+
+Opm::CellSetValues::SizeType
+Opm::CellSetValues::cellValueCount() const
+{
+    return assoc_.size();
+}
+
+Opm::CellSetValues::CellValue
+Opm::CellSetValues::cellValue(const SizeType cellValueIndex) const
+{
+    const auto& a = assoc_[cellValueIndex];
+
+    return { a.index, a.value };
+}

--- a/opm/flowdiagnostics/CellSetValues.hpp
+++ b/opm/flowdiagnostics/CellSetValues.hpp
@@ -1,0 +1,74 @@
+/*
+  Copyright 2016 Statoil ASA.
+  Copyright 2016 SINTEF ICT, Applied Mathematics.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_CELLSETVALUES_HEADER_INCLUDED
+#define OPM_CELLSETVALUES_HEADER_INCLUDED
+
+#include <utility>
+#include <vector>
+
+namespace Opm {
+
+    class CellSetValues
+    {
+    public:
+        using SizeType  = std::vector<int>::size_type;
+        using CellValue = std::pair<int, double>;
+
+        /// Constructor.
+        ///
+        /// @param[in] initialCapacity Number of elements that can be stored
+        ///            in set without reallocation.
+        explicit CellSetValues(const SizeType initialCapacity = 0);
+
+        /// Associate value with specific cell, represented by its index.
+        ///
+        /// @param[in] cellIndex Index of specific cell.
+        ///
+        /// @param[in] cellValue Value associated with cell @p cellIndex.
+        void addCellValue(const int    cellIndex,
+                          const double cellValue);
+
+        /// Retrieve number of elements stored in set.
+        SizeType cellValueCount() const;
+
+        /// Retrieve value association for single set element.
+        ///
+        /// @param[in] cellValueIndex Linear ID of single cell->value
+        ///            association.  Must be in the range @code [0,
+        ///            cellValueCount()) @endcode.
+        ///
+        /// @returns Single association between cell index and numerical
+        /// value.
+        CellValue cellValue(const SizeType cellValueIndex) const;
+
+    private:
+        struct Association
+        {
+            int    index;
+            double value;
+        };
+
+        std::vector<Association> assoc_;
+    };
+
+} // namespace Opm
+
+#endif // OPM_CELLSETVALUES_HEADER_INCLUDED

--- a/opm/flowdiagnostics/ConnectionValues.cpp
+++ b/opm/flowdiagnostics/ConnectionValues.cpp
@@ -1,0 +1,74 @@
+/*
+  Copyright 2016 SINTEF ICT, Applied Mathematics.
+  Copyright 2016 Statoil ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif // HAVE_CONFIG_H
+
+#include <opm/flowdiagnostics/ConnectionValues.hpp>
+
+#include <exception>
+#include <stdexcept>
+
+Opm::ConnectionValues::
+ConnectionValues(const NumConnections& nconn,
+                 const NumPhases&      nphase)
+    : nconn_ (nconn)
+    , nphase_(nphase)
+    , data_  (nconn_.total * nphase_.total, 0.0)
+{}
+
+std::vector<double>::size_type
+Opm::ConnectionValues::numConnections() const
+{
+    return nconn_.total;
+}
+
+std::size_t
+Opm::ConnectionValues::numPhases() const
+{
+    return nphase_.total;
+}
+
+double
+Opm::ConnectionValues::operator()(const ConnID&  conn,
+                                  const PhaseID& phase) const
+{
+    if ((conn .id >= nconn_ .total) ||
+        (phase.id >= nphase_.total))
+    {
+        throw std::logic_error("(Connection,Phase) pair out of range");
+    }
+
+    return data_[conn.id*nphase_.total + phase.id];
+}
+
+double&
+Opm::ConnectionValues::operator()(const ConnID&  conn,
+                                  const PhaseID& phase)
+{
+    if ((conn .id >= nconn_ .total) ||
+        (phase.id >= nphase_.total))
+    {
+        throw std::logic_error("(Connection,Phase) pair out of range");
+    }
+
+    return data_[conn.id*nphase_.total + phase.id];
+}

--- a/opm/flowdiagnostics/ConnectionValues.hpp
+++ b/opm/flowdiagnostics/ConnectionValues.hpp
@@ -1,0 +1,72 @@
+/*
+  Copyright 2016 Statoil ASA.
+  Copyright 2016 SINTEF ICT, Applied Mathematics.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_CONNECTIONVALUES_HEADER_INCLUDED
+#define OPM_CONNECTIONVALUES_HEADER_INCLUDED
+
+#include <cstddef>
+#include <vector>
+
+namespace Opm
+{
+    class ConnectionValues
+    {
+    public:
+        struct NumConnections
+        {
+            std::vector<double>::size_type total;
+        };
+
+        struct NumPhases
+        {
+            std::size_t total;
+        };
+
+        struct ConnID
+        {
+            std::vector<double>::size_type id;
+        };
+
+        struct PhaseID
+        {
+            std::size_t id;
+        };
+
+        ConnectionValues(const NumConnections& nconn,
+                         const NumPhases&      nphase);
+
+        std::vector<double>::size_type numConnections() const;
+        std::size_t                    numPhases()      const;
+
+        double operator()(const ConnID&  connection,
+                          const PhaseID& phase) const;
+
+        double& operator()(const ConnID&  connection,
+                           const PhaseID& phase);
+
+    private:
+        NumConnections      nconn_;
+        NumPhases           nphase_;
+
+        std::vector<double> data_;
+    };
+} // namespace Opm
+
+#endif // OPM_CONNECTIONVALUES_HEADER_INCLUDED

--- a/opm/flowdiagnostics/ConnectivityGraph.cpp
+++ b/opm/flowdiagnostics/ConnectivityGraph.cpp
@@ -1,0 +1,71 @@
+/*
+  Copyright 2016 SINTEF ICT, Applied Mathematics.
+  Copyright 2016 Statoil ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif // HAVE_CONFIG_H
+    
+#include <opm/flowdiagnostics/ConnectivityGraph.hpp>
+
+#include <algorithm>
+#include <cassert>
+#include <exception>
+#include <stdexcept>
+#include <utility>
+
+Opm::ConnectivityGraph::ConnectivityGraph(const int        num_cells,
+                                          std::vector<int> connection_to_cell)
+    : numCells_ (num_cells)
+    , connCells_(std::move(connection_to_cell))
+{
+    if ((connCells_.size() % 2) != 0) {
+        throw std::logic_error("Neighbourship must be N-by-2");
+    }
+
+    if ((! connCells_.empty()) &&
+        (*std::max_element(connCells_.begin(),
+                           connCells_.end())
+         >= num_cells))
+    {
+        throw std::logic_error("Cell indices must be in range");
+    }
+}
+
+Opm::ConnectivityGraph::SizeType
+Opm::ConnectivityGraph::numCells() const
+{
+    return numCells_;
+}
+
+Opm::ConnectivityGraph::SizeType
+Opm::ConnectivityGraph::numConnections() const
+{
+    return connCells_.size() / 2;
+}
+
+Opm::ConnectivityGraph::CellPair
+Opm::ConnectivityGraph::connection(const SizeType i) const
+{
+    assert (i < numConnections());
+
+    const auto* const start = &connCells_[2*i + 0];
+
+    return { *(start + 0), *(start + 1) };
+}

--- a/opm/flowdiagnostics/ConnectivityGraph.hpp
+++ b/opm/flowdiagnostics/ConnectivityGraph.hpp
@@ -1,0 +1,60 @@
+/*
+  Copyright 2016 Statoil ASA.
+  Copyright 2016 SINTEF ICT, Applied Mathematics.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_CONNECTIVITYGRAPH_HEADER_INCLUDED
+#define OPM_CONNECTIVITYGRAPH_HEADER_INCLUDED
+
+#include <vector>
+
+namespace Opm
+{
+    class ConnectivityGraph
+    {
+    public:
+        /// Construct from explicit neighbourship table.
+        ///
+        /// The @p connection_to_cell must have size equal to @code 2 * E
+        /// @endcode in which @c E is the number of connections.  Connection
+        /// @c k connects cells @code connection_to_cell[2*k + 0] @endcode
+        /// and @code connection_to_cell[2*k + 1] @endcode.
+        ConnectivityGraph(const int        num_cells,
+                          std::vector<int> connection_to_cell);
+
+        struct CellPair
+        {
+            int first;
+            int second;
+        };
+
+        using SizeType = std::vector<int>::size_type;
+
+        SizeType numCells()      const;
+        SizeType numConnections() const;
+
+        CellPair connection(const SizeType i) const;
+
+    private:
+        SizeType         numCells_;
+        std::vector<int> connCells_;
+    };
+
+} // namespace Opm
+
+#endif // OPM_CONNECTIVITYGRAPH_HEADER_INCLUDED

--- a/opm/flowdiagnostics/FlowDiagnosticsTool.cpp
+++ b/opm/flowdiagnostics/FlowDiagnosticsTool.cpp
@@ -186,7 +186,7 @@ Impl::solutionValues(const CellSetID&   i,
     auto p = soln.find(i);
 
     if (p == soln.end()) {
-        return {};
+        return CellSetValues{};
     }
 
     return p->second;

--- a/opm/flowdiagnostics/FlowDiagnosticsTool.cpp
+++ b/opm/flowdiagnostics/FlowDiagnosticsTool.cpp
@@ -1,0 +1,444 @@
+/*
+  Copyright 2016 SINTEF ICT, Applied Mathematics.
+  Copyright 2016 Statoil ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif // HAVE_CONFIG_H
+
+#include <opm/flowdiagnostics/FlowDiagnosticsTool.hpp>
+
+#include <opm/flowdiagnostics/CellSet.hpp>
+#include <opm/flowdiagnostics/ConnectionValues.hpp>
+#include <opm/flowdiagnostics/ConnectivityGraph.hpp>
+
+#include <algorithm>
+#include <exception>
+#include <map>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <opm/flowdiagnostics/utility/RandomVector.hpp>
+
+namespace { namespace Mock {
+
+    std::vector<double>
+    FieldValue(const std::vector<double>::size_type n,
+               const double mean, const double stdev)
+    {
+        static Opm::Utility::RandomVector genRandom{};
+
+        return genRandom.normal(n, mean, stdev);
+    }
+
+    std::vector<int>
+    Index(const std::vector<double>::size_type n,
+          const int maxIdx)
+    {
+        static Opm::Utility::RandomVector genRandom{};
+
+        return genRandom.index(n, maxIdx);
+    }
+
+}} // namespace (anonymous)::Mock
+
+// ---------------------------------------------------------------------
+// Class Opm::FlowDiagnosticsSolution::Impl
+// ---------------------------------------------------------------------
+
+class Opm::FlowDiagnosticsSolution::Impl
+{
+public:
+    using GlobalToF = std::vector<double>;
+
+    struct TimeOfFlight
+    {
+        CellSetValues data;
+    };
+
+    struct Concentration
+    {
+        CellSetValues data;
+    };
+
+    void assignToF(GlobalToF&& tof);
+    void assign   (const CellSetID& i, TimeOfFlight&&  tof);
+    void assign   (const CellSetID& i, Concentration&& conc);
+
+    std::vector<CellSetID> startPoints() const;
+
+    const GlobalToF& timeOfFlight() const;
+
+    CellSetValues timeOfFlight (const CellSetID& tracer) const;
+    CellSetValues concentration(const CellSetID& tracer) const;
+
+private:
+    struct CompareCellSetIDs
+    {
+        bool operator()(const CellSetID& x,
+                        const CellSetID& y) const
+        {
+            return x.to_string() < y.to_string();
+        }
+    };
+
+    using SolutionMap =
+        std::map<CellSetID, CellSetValues, CompareCellSetIDs>;
+
+    GlobalToF   tof_;
+    SolutionMap tracerToF_;
+    SolutionMap tracer_;
+
+    void assign(const CellSetID& i,
+                CellSetValues&&  x,
+                SolutionMap&     soln);
+
+    CellSetValues
+    solutionValues(const CellSetID&   i,
+                   const SolutionMap& soln) const;
+};
+
+void
+Opm::FlowDiagnosticsSolution::Impl::assignToF(GlobalToF&& tof)
+{
+    tof_ = std::move(tof);
+}
+
+void
+Opm::FlowDiagnosticsSolution::
+Impl::assign(const CellSetID& i, TimeOfFlight&& tof)
+{
+    assign(i, std::move(tof.data), tracerToF_);
+}
+
+void
+Opm::FlowDiagnosticsSolution::
+Impl::assign(const CellSetID& i, Concentration&& conc)
+{
+    assign(i, std::move(conc.data), tracer_);
+}
+
+std::vector<Opm::CellSetID>
+Opm::FlowDiagnosticsSolution::Impl::startPoints() const
+{
+    auto s = std::vector<CellSetID>{};
+    s.reserve(tracer_.size());
+
+    for (const auto& t : tracer_) {
+        s.emplace_back(t.first);
+    }
+
+    return s;
+}
+
+const Opm::FlowDiagnosticsSolution::Impl::GlobalToF&
+Opm::FlowDiagnosticsSolution::Impl::timeOfFlight() const
+{
+    return tof_;
+}
+
+Opm::CellSetValues
+Opm::FlowDiagnosticsSolution::
+Impl::timeOfFlight(const CellSetID& tracer) const
+{
+    return solutionValues(tracer, tracerToF_);
+}
+
+Opm::CellSetValues
+Opm::FlowDiagnosticsSolution::
+Impl::concentration(const CellSetID& tracer) const
+{
+    return solutionValues(tracer, tracer_);
+}
+
+void
+Opm::FlowDiagnosticsSolution::
+Impl::assign(const CellSetID& i,
+             CellSetValues&&  x,
+             SolutionMap&     soln)
+{
+    soln[i] = std::move(x);
+}
+
+Opm::CellSetValues
+Opm::FlowDiagnosticsSolution::
+Impl::solutionValues(const CellSetID&   i,
+                     const SolutionMap& soln) const
+{
+    auto p = soln.find(i);
+
+    if (p == soln.end()) {
+        return {};
+    }
+
+    return p->second;
+}
+
+// ---------------------------------------------------------------------
+// Class Opm::FlowDiagnosticsTool::Impl
+// ---------------------------------------------------------------------
+
+class Opm::FlowDiagnosticsTool::Impl
+{
+public:
+    explicit Impl(ConnectivityGraph g);
+
+    void assign(const PoreVolume&     pv);
+    void assign(const ConnectionFlux& flux);
+
+    Forward injDiag (const StartCells& start);
+    Reverse prodDiag(const StartCells& start);
+
+private:
+    ConnectivityGraph g_;
+
+    std::vector<double> pvol_;
+    ConnectionValues    flux_;
+};
+
+Opm::FlowDiagnosticsTool::Impl::Impl(ConnectivityGraph g)
+    : g_   (std::move(g))
+    , pvol_(g_.numCells(), 0.0)
+    , flux_(ConnectionValues::NumConnections{ 0 },
+            ConnectionValues::NumPhases     { 0 })
+{}
+
+void
+Opm::FlowDiagnosticsTool::Impl::assign(const PoreVolume& pv)
+{
+    if (pv.data.size() != pvol_.size()) {
+        throw std::logic_error("Inconsistently sized input "
+                               "pore-volume field");
+    }
+
+    pvol_ = pv.data;
+}
+
+void
+Opm::FlowDiagnosticsTool::Impl::assign(const ConnectionFlux& flux)
+{
+    if (flux.data.numConnections() != g_.numConnections()) {
+        throw std::logic_error("Inconsistently sized input "
+                               "flux field");
+    }
+
+    flux_ = flux.data;
+}
+
+Opm::FlowDiagnosticsTool::Forward
+Opm::FlowDiagnosticsTool::Impl::injDiag(const StartCells& start)
+{
+    using SampleSize = Opm::Utility::RandomVector::Size;
+    using Soln       = FlowDiagnosticsSolution::Impl;
+    using ToF        = Soln::TimeOfFlight;
+    using Conc       = Soln::Concentration;
+
+    using SolnPtr = std::unique_ptr<Soln>;
+
+    SolnPtr x(new Soln());
+
+    const auto avgToF = 20.0e3;
+    const auto stdToF = 500.0;
+
+    x->assignToF(Mock::FieldValue(g_.numCells(), avgToF, stdToF));
+
+    for (const auto& pt : start.points)
+    {
+        const auto npts = static_cast<SampleSize>
+            (std::distance(pt.begin(), pt.end()));
+
+        const auto n = std::min(
+            { npts, g_.numCells(), static_cast<SampleSize>(100) }
+        );
+
+        const auto idx = Mock::Index(n, g_.numCells() - 1);
+
+        {
+            const auto tof = Mock::FieldValue(n, avgToF, stdToF);
+
+            auto val = CellSetValues{ n };
+            for (auto i = 0*n; i < n; ++i) {
+                val.addCellValue(idx[i], tof[i]);
+            }
+
+            x->assign(pt.id(), ToF{ val });
+        }
+
+        {
+            const auto conc = Mock::FieldValue(n, 0.5, 0.15);
+
+            auto val = CellSetValues{ n };
+            for (auto i = 0*n; i < n; ++i) {
+                val.addCellValue(idx[i], conc[i]);
+            }
+
+            x->assign(pt.id(), Conc{ val });
+        }
+    }
+
+    return Forward{ FlowDiagnosticsSolution(std::move(x)) };
+}
+
+Opm::FlowDiagnosticsTool::Reverse
+Opm::FlowDiagnosticsTool::Impl::prodDiag(const StartCells& start)
+{
+    using SampleSize = Opm::Utility::RandomVector::Size;
+    using Soln       = FlowDiagnosticsSolution::Impl;
+    using ToF        = Soln::TimeOfFlight;
+    using Conc       = Soln::Concentration;
+
+    using SolnPtr = std::unique_ptr<Soln>;
+
+    SolnPtr x(new Soln());
+
+    const auto avgToF = 20.0e3;
+    const auto stdToF = 500.0;
+
+    x->assignToF(Mock::FieldValue(g_.numCells(), avgToF, stdToF));
+
+    for (const auto& pt : start.points)
+    {
+        const auto npts = static_cast<SampleSize>
+            (std::distance(pt.begin(), pt.end()));
+
+        const auto n = std::min(
+            { npts, g_.numCells(), static_cast<SampleSize>(100) }
+        );
+
+        const auto idx = Mock::Index(n, g_.numCells() - 1);
+
+        {
+            const auto tof = Mock::FieldValue(n, avgToF, stdToF);
+
+            auto val = CellSetValues{ n };
+            for (auto i = 0*n; i < n; ++i) {
+                val.addCellValue(idx[i], tof[i]);
+            }
+
+            x->assign(pt.id(), ToF{ val });
+        }
+
+        {
+            const auto conc = Mock::FieldValue(n, 0.5, 0.15);
+
+            auto val = CellSetValues{ n };
+            for (auto i = 0*n; i < n; ++i) {
+                val.addCellValue(idx[i], conc[i]);
+            }
+
+            x->assign(pt.id(), Conc{ val });
+        }
+    }
+
+    return Reverse{ FlowDiagnosticsSolution(std::move(x)) };
+}
+
+// =====================================================================
+// Implementation of public interface below separator
+// =====================================================================
+
+// ---------------------------------------------------------------------
+// Class Opm::FlowDiagnosticsSolution
+// ---------------------------------------------------------------------
+
+Opm::FlowDiagnosticsSolution::~FlowDiagnosticsSolution()
+{}
+
+Opm::FlowDiagnosticsSolution::
+FlowDiagnosticsSolution(const FlowDiagnosticsSolution& rhs)
+    : pImpl_(new Impl(*rhs.pImpl_))
+{}
+
+Opm::FlowDiagnosticsSolution::
+FlowDiagnosticsSolution(FlowDiagnosticsSolution&& rhs)
+    : pImpl_(std::move(rhs.pImpl_))
+{}
+
+Opm::FlowDiagnosticsSolution::
+FlowDiagnosticsSolution(std::unique_ptr<Impl> pImpl)
+    : pImpl_(std::move(pImpl))
+{}
+
+std::vector<Opm::CellSetID>
+Opm::FlowDiagnosticsSolution::startPoints() const
+{
+    return pImpl_->startPoints();
+}
+
+const std::vector<double>&
+Opm::FlowDiagnosticsSolution::timeOfFlight() const
+{
+    return pImpl_->timeOfFlight();
+}
+
+Opm::CellSetValues
+Opm::FlowDiagnosticsSolution::timeOfFlight(const CellSetID& tracer) const
+{
+    return pImpl_->timeOfFlight(tracer);
+}
+
+Opm::CellSetValues
+Opm::FlowDiagnosticsSolution::concentration(const CellSetID& tracer) const
+{
+    return pImpl_->concentration(tracer);
+}
+
+// ---------------------------------------------------------------------
+// Class Opm::FlowDiagnosticsTool
+// ---------------------------------------------------------------------
+
+Opm::FlowDiagnosticsTool::
+FlowDiagnosticsTool(const ConnectivityGraph& conn)
+    : pImpl_(new Impl(conn))
+{}
+
+Opm::FlowDiagnosticsTool::~FlowDiagnosticsTool()
+{}
+
+Opm::FlowDiagnosticsTool&
+Opm::FlowDiagnosticsTool::assign(const PoreVolume& pv)
+{
+    pImpl_->assign(pv);
+
+    return *this;
+}
+
+Opm::FlowDiagnosticsTool&
+Opm::FlowDiagnosticsTool::assign(const ConnectionFlux& flux)
+{
+    pImpl_->assign(flux);
+
+    return *this;
+}
+
+Opm::FlowDiagnosticsTool::Forward
+Opm::FlowDiagnosticsTool::
+computeInjectionDiagnostics(const StartCells& start)
+{
+    return pImpl_->injDiag(start);
+}
+
+Opm::FlowDiagnosticsTool::Reverse
+Opm::FlowDiagnosticsTool::
+computeProductionDiagnostics(const StartCells& start)
+{
+    return pImpl_->prodDiag(start);
+}

--- a/opm/flowdiagnostics/FlowDiagnosticsTool.hpp
+++ b/opm/flowdiagnostics/FlowDiagnosticsTool.hpp
@@ -1,0 +1,148 @@
+/*
+  Copyright 2016 Statoil ASA.
+  Copyright 2016 SINTEF ICT, Applied Mathematics.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_FLOWDIAGNOSTICSTOOL_HEADER_INCLUDED
+#define OPM_FLOWDIAGNOSTICSTOOL_HEADER_INCLUDED
+
+#include <opm/flowdiagnostics/CellSet.hpp>
+#include <opm/flowdiagnostics/CellSetValues.hpp>
+
+#include <memory>
+#include <vector>
+
+namespace Opm
+{
+    // These classes are not defined for the moment, definitions will
+    // depend on needs and be refined as we progress.
+
+    // Nodes are cells, edges are connections.  Wells not included.
+    class ConnectivityGraph;
+
+    // One element per phase for each connection.
+    class ConnectionValues;
+
+    /// Toolbox for running flow diagnostics.
+    class FlowDiagnosticsTool;
+
+    /// Results from diagnostics computations.
+    class FlowDiagnosticsSolution
+    {
+    public:
+        ~FlowDiagnosticsSolution();
+
+        FlowDiagnosticsSolution(const FlowDiagnosticsSolution& rhs);
+        FlowDiagnosticsSolution(FlowDiagnosticsSolution&& rhs);
+
+        /// Ids of stored tracer solutions.
+        std::vector<CellSetID> startPoints() const;
+
+        /// Time-of-flight field from all start points.
+        const std::vector<double>& timeOfFlight() const;
+
+        /// Time-of-flight field restricted to single tracer region.
+        CellSetValues timeOfFlight(const CellSetID& tracer) const;
+
+        /// The computed tracer field corresponding to a single tracer.
+        ///
+        /// The \c tracer must correspond to an id passed in
+        /// computeX...Diagnostics().
+        CellSetValues concentration(const CellSetID& tracer) const;
+
+        friend class FlowDiagnosticsTool;
+
+    private:
+        class Impl;
+
+        explicit FlowDiagnosticsSolution(std::unique_ptr<Impl> pImpl);
+
+        std::unique_ptr<Impl> pImpl_;
+    };
+
+    /// Toolbox for running flow diagnostics.
+    class FlowDiagnosticsTool
+    {
+    public:
+        /// Construct from known neighbourship relation.
+        explicit FlowDiagnosticsTool(const ConnectivityGraph& connectivity);
+
+        ~FlowDiagnosticsTool();
+
+        struct PoreVolume
+        {
+            const std::vector<double>& data;
+        };
+
+        struct ConnectionFlux
+        {
+            const ConnectionValues& data;
+        };
+
+        struct StartCells
+        {
+            const std::vector<CellSet>& points;
+        };
+
+        struct Forward
+        {
+            const FlowDiagnosticsSolution fd;
+        };
+
+        struct Reverse
+        {
+            const FlowDiagnosticsSolution fd;
+        };
+
+        FlowDiagnosticsTool& assign(const PoreVolume&     pv);
+        FlowDiagnosticsTool& assign(const ConnectionFlux& flux);
+
+        /// Compute forward time-of-flight and tracer solutions.
+        ///
+        /// An element of \code start.points \endcode provides a set of
+        /// starting locations for a single tracer.
+        ///
+        /// Forward time-of-flight is the time needed for a neutral fluid
+        /// particle to flow from the nearest fluid source to an arbitrary
+        /// point in the model.  The tracer solutions identify cells that
+        /// are flooded by injectors.
+        ///
+        /// The IDs of the \code start.points \endcode must be unique.
+        Forward computeInjectionDiagnostics(const StartCells& start);
+
+        /// Compute reverse time-of-flight and tracer solutions.
+        ///
+        /// An element of \code start.points \endcode provides a set of
+        /// starting locations for a single tracer.
+        ///
+        /// Reverse time-of-flight is the time needed for a neutral fluid
+        /// particle to flow from an arbitrary point to the nearest fluid
+        /// sink in the model.  The tracer solutions identify cells that are
+        /// drained by producers.
+        ///
+        /// The IDs of the \code start.points \endcode must be unique.
+        Reverse computeProductionDiagnostics(const StartCells& start);
+
+    private:
+        class Impl;
+
+        std::unique_ptr<Impl> pImpl_;
+    };
+} // namespace Opm
+
+#endif // OPM_FLOWDIAGNOSTICSTOOL_HEADER_INCLUDED

--- a/opm/flowdiagnostics/utility/RandomVector.cpp
+++ b/opm/flowdiagnostics/utility/RandomVector.cpp
@@ -1,0 +1,100 @@
+/*
+  Copyright 2016 SINTEF ICT, Applied Mathematics.
+  Copyright 2016 Statoil ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif // HAVE_CONFIG_H
+
+#include <opm/flowdiagnostics/utility/RandomVector.hpp>
+
+#include <random>
+
+class Opm::Utility::RandomVector::Impl
+{
+public:
+    Sample normal(const Size   n,
+                  const double mean,
+                  const double stdev);
+
+    std::vector<int> integer(const Size n,
+                             const int  min,
+                             const int  max);
+
+private:
+    using BitGenerator = std::mt19937;
+
+    BitGenerator gen_;
+};
+
+Opm::Utility::RandomVector::Sample
+Opm::Utility::RandomVector::
+Impl::normal(const Size n, const double mean, const double stdev)
+{
+    auto distr = std::normal_distribution<>{ mean, stdev };
+
+    auto sample = Sample{};
+    sample.reserve(n);
+
+    for (auto i = 0*n; i < n; ++i) {
+        sample.push_back(distr(gen_));
+    }
+
+    return sample;
+}
+
+std::vector<int>
+Opm::Utility::RandomVector::
+Impl::integer(const Size n, const int min, const int max
+)
+{
+    auto distr = std::uniform_int_distribution<>{ min, max };
+
+    auto idx = std::vector<int>{};
+    idx.reserve(n);
+
+    for (auto i = 0*n; i < n; ++i) {
+        idx.push_back(distr(gen_));
+    }
+
+    return idx;
+}
+
+// =====================================================================
+
+Opm::Utility::RandomVector::RandomVector()
+    : pImpl_(new Impl())
+{}
+
+Opm::Utility::RandomVector::~RandomVector()
+{}
+
+Opm::Utility::RandomVector::Sample
+Opm::Utility::RandomVector::normal(const Size   n,
+                                   const double mean,
+                                   const double stdev)
+{
+    return pImpl_->normal(n, mean, stdev);
+}
+
+std::vector<int>
+Opm::Utility::RandomVector::index(const Size n, const int maxIdx)
+{
+    return pImpl_->integer(n, 0, maxIdx);
+}

--- a/opm/flowdiagnostics/utility/RandomVector.hpp
+++ b/opm/flowdiagnostics/utility/RandomVector.hpp
@@ -1,0 +1,56 @@
+/*
+  Copyright 2016 SINTEF ICT, Applied Mathematics.
+  Copyright 2016 Statoil ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <memory>
+#include <vector>
+
+namespace Opm
+{
+    namespace Utility
+    {
+        class RandomVector
+        {
+        public:
+            using Sample = std::vector<double>;
+            using Size   = Sample::size_type;
+
+            RandomVector();
+            ~RandomVector();
+
+            RandomVector(const RandomVector& rhs) = delete;
+            RandomVector(RandomVector&&      rhs) = delete;
+
+            RandomVector& operator=(const RandomVector& rhs) = delete;
+            RandomVector& operator=(RandomVector&&      rhs) = delete;
+
+            Sample normal(const Size   n,
+                          const double mean  = 0.0,
+                          const double stdev = 1.0);
+
+            std::vector<int> index(const Size n,
+                                   const int  maxIdx);
+
+        private:
+            class Impl;
+
+            std::unique_ptr<Impl> pImpl_;
+        };
+    }
+} // namespace Opm

--- a/tests/test_cellset.cpp
+++ b/tests/test_cellset.cpp
@@ -1,0 +1,123 @@
+/*
+  Copyright 2016 SINTEF ICT, Applied Mathematics.
+  Copyright 2016 Statoil ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <config.h>
+
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
+
+#define NVERBOSE
+
+#define BOOST_TEST_MODULE TEST_CELLSET
+
+#include <boost/test/unit_test.hpp>
+
+#include <opm/flowdiagnostics/CellSet.hpp>
+
+#include <algorithm>
+
+BOOST_AUTO_TEST_SUITE(CellSetID)
+
+BOOST_AUTO_TEST_CASE (Construct)
+{
+    {
+        const auto i = Opm::CellSetID{};
+
+        BOOST_CHECK_EQUAL(i.to_string(), "");
+    }
+
+    {
+        const auto name = std::string("Injection");
+
+        const auto i = Opm::CellSetID(name);
+
+        BOOST_CHECK_EQUAL(i.to_string(), name);
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+
+BOOST_AUTO_TEST_SUITE(CellSet)
+
+BOOST_AUTO_TEST_CASE (Constructor)
+{
+    {
+        auto s = Opm::CellSet{};
+
+        BOOST_CHECK_EQUAL(s.id().to_string(), "");
+    }
+
+    {
+        const auto name = std::string("Test-Ctor");
+
+        auto s = Opm::CellSet{};
+        {
+            s.identify(Opm::CellSetID(name));
+        }
+
+        BOOST_CHECK_EQUAL(s.id().to_string(), name);
+    }
+}
+
+BOOST_AUTO_TEST_CASE (AssignCells)
+{
+    auto s = Opm::CellSet{};
+
+    const auto cells = std::vector<int>
+        { 0, 1, 2, 5, 10, 20, 50, 100, 200, 500, 1000 };
+
+    for (const auto& cell : cells) {
+        s.insert(cell);
+    }
+
+    auto out = std::vector<int>(s.begin(), s.end());
+    {
+        std::sort(out.begin(), out.end());
+    }
+
+    BOOST_CHECK_EQUAL_COLLECTIONS(out  .begin(), out  .end(),
+                                  cells.begin(), cells.end());
+}
+
+BOOST_AUTO_TEST_CASE (Duplicates)
+{
+    auto s = Opm::CellSet{};
+
+    const auto cells = std::vector<int>
+        { 0, 1, 2, 5, 10, 20, 50, 100, 200, 500, 1000 };
+
+    for (auto i = 0; i < 2; ++i) {
+        for (const auto& cell : cells) {
+            s.insert(cell);
+        }
+    }
+
+    auto out = std::vector<int>(s.begin(), s.end());
+    {
+        std::sort(out.begin(), out.end());
+    }
+
+    BOOST_CHECK_EQUAL_COLLECTIONS(out  .begin(), out  .end(),
+                                  cells.begin(), cells.end());
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_cellsetvalues.cpp
+++ b/tests/test_cellsetvalues.cpp
@@ -1,0 +1,85 @@
+/*
+  Copyright 2016 SINTEF ICT, Applied Mathematics.
+  Copyright 2016 Statoil ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif // HAVE_CONFIG_H
+
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
+
+#define NVERBOSE
+
+#define BOOST_TEST_MODULE TEST_CELLSETVALUES
+
+#include <boost/test/unit_test.hpp>
+
+#include <opm/flowdiagnostics/CellSetValues.hpp>
+
+BOOST_AUTO_TEST_SUITE(CellSet_Values)
+
+BOOST_AUTO_TEST_CASE (Constructor)
+{
+    {
+        Opm::CellSetValues s{};
+    }
+
+    {
+        auto s = Opm::CellSetValues{ 100 };
+    }
+}
+
+BOOST_AUTO_TEST_CASE (AssignValues)
+{
+    auto s = Opm::CellSetValues{ 100 };
+
+    for (decltype(s.cellValueCount())
+             i = 0, n = 100;
+         i < n; ++i)
+    {
+        s.addCellValue(100 - i, i * 10.0);
+    }
+
+    BOOST_CHECK_EQUAL(s.cellValueCount(), 100);
+
+    {
+        const auto a = s.cellValue(0);
+
+        BOOST_CHECK_EQUAL(a.first , 100);
+        BOOST_CHECK_CLOSE(a.second, 0.0, 1.0e-10);
+    }
+
+    {
+        const auto a = s.cellValue(s.cellValueCount() - 1);
+
+        BOOST_CHECK_EQUAL(a.first , 1);
+        BOOST_CHECK_CLOSE(a.second, 990.0, 1.0e-10);
+    }
+
+    {
+        const auto a = s.cellValue(50);
+
+        BOOST_CHECK_EQUAL(a.first , 50);
+        BOOST_CHECK_CLOSE(a.second, 500.0, 1.0e-10);
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_connectivitygraph.cpp
+++ b/tests/test_connectivitygraph.cpp
@@ -1,0 +1,90 @@
+/*
+  Copyright 2016 SINTEF ICT, Applied Mathematics.
+  Copyright 2016 Statoil ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif // HAVE_CONFIG_H
+
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
+
+#define NVERBOSE
+
+#define BOOST_TEST_MODULE TEST_CONNECTIVITY_GRAPH
+
+#include <boost/test/unit_test.hpp>
+
+#include <opm/flowdiagnostics/ConnectivityGraph.hpp>
+
+BOOST_AUTO_TEST_SUITE(Two_By_Two)
+
+BOOST_AUTO_TEST_CASE (Constructor)
+{
+    const auto g =
+        Opm::ConnectivityGraph(4,
+                               { 0 , 1 ,
+                                 0 , 2 ,
+                                 1 , 3 ,
+                                 2 , 3 });
+
+    BOOST_CHECK_EQUAL(g.numCells(),       4);
+    BOOST_CHECK_EQUAL(g.numConnections(), 4);
+}
+
+BOOST_AUTO_TEST_CASE (ConnectionList)
+{
+    const auto g =
+        Opm::ConnectivityGraph(4,
+                               { 0, 1 ,
+                                 0, 2 ,
+                                 1, 3 ,
+                                 2, 3 });
+
+    {
+        const auto c = g.connection(0);
+
+        BOOST_CHECK_EQUAL(c.first , 0);
+        BOOST_CHECK_EQUAL(c.second, 1);
+    }
+
+    {
+        const auto c = g.connection(1);
+
+        BOOST_CHECK_EQUAL(c.first , 0);
+        BOOST_CHECK_EQUAL(c.second, 2);
+    }
+
+    {
+        const auto c = g.connection(2);
+
+        BOOST_CHECK_EQUAL(c.first , 1);
+        BOOST_CHECK_EQUAL(c.second, 3);
+    }
+
+    {
+        const auto c = g.connection(3);
+
+        BOOST_CHECK_EQUAL(c.first , 2);
+        BOOST_CHECK_EQUAL(c.second, 3);
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_flowdiagnosticstool.cpp
+++ b/tests/test_flowdiagnosticstool.cpp
@@ -1,0 +1,272 @@
+/*
+  Copyright 2016 SINTEF ICT, Applied Mathematics.
+  Copyright 2016 Statoil ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif // HAVE_CONFIG_H
+
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif // HAVE_DYNAMIC_BOOST_TEST
+
+#define NVERBOSE
+
+#define BOOST_TEST_MODULE TEST_FLOWDIAGNOSTICSTOOL
+
+#include <boost/test/unit_test.hpp>
+
+#include <opm/flowdiagnostics/FlowDiagnosticsTool.hpp>
+
+#include <opm/flowdiagnostics/CellSet.hpp>
+#include <opm/flowdiagnostics/ConnectionValues.hpp>
+#include <opm/flowdiagnostics/ConnectivityGraph.hpp>
+#include <opm/flowdiagnostics/utility/RandomVector.hpp>
+
+#include <algorithm>
+
+namespace
+{
+    std::size_t
+    numIntConn(const std::size_t nx,
+               const std::size_t ny)
+    {
+        return (nx - 1)*ny + nx*(ny - 1);
+    }
+
+    std::vector<int>
+    internalConnections(const std::size_t nx,
+                        const std::size_t ny)
+    {
+        auto cellID = [](const std::size_t start,
+                         const std::size_t off)
+        {
+            return static_cast<int>(start + off);
+        };
+
+        auto neighbours = std::vector<int>{};
+        neighbours.reserve(2 * numIntConn(nx, ny));
+
+        // I connections
+        {
+            for (auto j = 0*ny; j < ny; ++j) {
+                const auto start = j * nx;
+
+                for (auto i = 0*nx + 1; i < nx; ++i) {
+                    neighbours.push_back(cellID(start, i - 1));
+                    neighbours.push_back(cellID(start, i - 0));
+                }
+            }
+        }
+
+        // J connections
+        {
+            for (auto j = 0*ny + 1; j < ny; ++j) {
+                const auto start = (j - 1)*nx;
+
+                for (auto i = 0*nx; i < nx; ++i) {
+                    neighbours.push_back(cellID(start, i + 0 ));
+                    neighbours.push_back(cellID(start, i + nx));
+                }
+            }
+        }
+
+        return neighbours;
+    }
+
+    std::vector<double>
+    flowField(const std::vector<double>::size_type n)
+    {
+        static Opm::Utility::RandomVector genRandom{};
+
+        return genRandom.normal(n);
+    }
+
+} // Namespace anonymous
+
+class Setup
+{
+public:
+    Setup(const std::size_t nx,
+          const std::size_t ny);
+
+    const Opm::ConnectivityGraph& connectivity() const;
+    const std::vector<double>&    poreVolume()   const;
+    const Opm::ConnectionValues&  flux()         const;
+
+private:
+    Opm::ConnectivityGraph g_;
+    std::vector<double>    pvol_;
+    Opm::ConnectionValues  flux_;
+};
+
+Setup::Setup(const std::size_t nx,
+             const std::size_t ny)
+    : g_   (nx * ny, internalConnections(nx, ny))
+    , pvol_(g_.numCells(), 0.3)
+    , flux_(Opm::ConnectionValues::NumConnections{ g_.numConnections() },
+            Opm::ConnectionValues::NumPhases     { 1 })
+{
+    const auto flux = flowField(g_.numConnections());
+
+    using ConnID = Opm::ConnectionValues::ConnID;
+
+    const auto phaseID =
+        Opm::ConnectionValues::PhaseID{ 0 };
+
+    for (decltype(flux_.numConnections())
+             conn = 0, nconn = flux_.numConnections();
+         conn < nconn; ++conn)
+    {
+        flux_(ConnID{conn}, phaseID) = flux[conn];
+    }
+}
+
+const Opm::ConnectivityGraph&
+Setup::connectivity() const
+{
+    return g_;
+}
+
+const std::vector<double>&
+Setup::poreVolume() const
+{
+    return pvol_;
+}
+
+const Opm::ConnectionValues&
+Setup::flux() const
+{
+    return flux_;
+}
+
+BOOST_AUTO_TEST_SUITE(FlowDiagnostics_Tool)
+
+BOOST_AUTO_TEST_CASE (Constructor)
+{
+    using FDT = Opm::FlowDiagnosticsTool;
+
+    const auto cas = Setup(2, 2);
+
+    FDT diagTool(cas.connectivity());
+
+    diagTool
+        .assign(FDT::PoreVolume{ cas.poreVolume() })
+        .assign(FDT::ConnectionFlux{ cas.flux() });
+}
+
+BOOST_AUTO_TEST_CASE (InjectionDiagnostics)
+{
+    using FDT = Opm::FlowDiagnosticsTool;
+
+    const auto cas = Setup(2, 2);
+
+    FDT diagTool(cas.connectivity());
+
+    diagTool
+        .assign(FDT::PoreVolume{ cas.poreVolume() })
+        .assign(FDT::ConnectionFlux{ cas.flux() });
+
+    auto start = std::vector<Opm::CellSet>{};
+    {
+        start.emplace_back();
+
+        auto& s = start.back();
+
+        s.identify(Opm::CellSetID("I-1"));
+        s.insert(0);
+    }
+
+    {
+        start.emplace_back();
+
+        auto& s = start.back();
+
+        s.identify(Opm::CellSetID("I-2"));
+        s.insert(cas.connectivity().numCells() - 1);
+    }
+
+    const auto fwd = diagTool
+        .computeInjectionDiagnostics(FDT::StartCells{start});
+
+    // Global ToF field (accumulated from all injectors)
+    {
+        const auto tof = fwd.fd.timeOfFlight();
+
+        BOOST_CHECK_EQUAL(tof.size(), cas.connectivity().numCells());
+    }
+
+    // Verify set of start points.
+    {
+        const auto startpts = fwd.fd.startPoints();
+
+        BOOST_CHECK_EQUAL(startpts.size(), start.size());
+
+        for (const auto& pt : startpts) {
+            auto pos =
+                std::find_if(start.begin(), start.end(),
+                    [&pt](const Opm::CellSet& s)
+                    {
+                        return s.id().to_string() == pt.to_string();
+                    });
+
+            // ID of 'pt' *MUST* be in set of identified start points.
+            BOOST_CHECK(pos != start.end());
+        }
+    }
+
+    // Tracer-ToF
+    {
+        const auto tof = fwd.fd
+            .timeOfFlight(Opm::CellSetID("I-1"));
+
+        for (decltype(tof.cellValueCount())
+                 i = 0, n = tof.cellValueCount();
+             i < n; ++i)
+        {
+            const auto v = tof.cellValue(i);
+
+            BOOST_TEST_MESSAGE("[" << i << "] -> ToF["
+                               << v.first << "] = "
+                               << v.second);
+        }
+    }
+
+    // Tracer Concentration
+    {
+        const auto conc = fwd.fd
+            .concentration(Opm::CellSetID("I-2"));
+
+        BOOST_TEST_MESSAGE("conc.cellValueCount() = " <<
+                           conc.cellValueCount());
+
+        for (decltype(conc.cellValueCount())
+                 i = 0, n = conc.cellValueCount();
+             i < n; ++i)
+        {
+            const auto v = conc.cellValue(i);
+
+            BOOST_TEST_MESSAGE("[" << i << "] -> Conc["
+                               << v.first << "] = "
+                               << v.second);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This change-set adds a first implementation of the public interface to the flow diagnostics kernels.  Details of how to construct the cell connectivity graph are mostly unanswered at this time.  We just assume that some external entity has undertaken this work.

Build tested on
- Linux Mint 17.2, GCC 4.9.2
- Ubuntu Linux 15.10, GCC 5.2.1
- Microsoft Windows 10, Visual Studio 2015 Update 2
