### PR TITLE
Add Support for Running Tarjan's SCC Algorithm on a Subgraph

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -30,10 +30,12 @@ list (APPEND MAIN_SOURCE_FILES
 	opm/flowdiagnostics/ConnectivityGraph.cpp
 	opm/flowdiagnostics/FlowDiagnosticsTool.cpp
 	opm/flowdiagnostics/reorder/tarjan.c
+	opm/flowdiagnostics/utility/AssembledConnections.cpp
 	opm/flowdiagnostics/utility/RandomVector.cpp
 	)
 
 list (APPEND TEST_SOURCE_FILES
+	tests/test_assembledconnections.cpp
 	tests/test_cellset.cpp
 	tests/test_cellsetvalues.cpp
 	tests/test_connectionvalues.cpp
@@ -48,5 +50,6 @@ list (APPEND PUBLIC_HEADER_FILES
 	opm/flowdiagnostics/ConnectionValues.hpp
 	opm/flowdiagnostics/ConnectivityGraph.hpp
 	opm/flowdiagnostics/FlowDiagnosticsTool.hpp
+	opm/flowdiagnostics/utility/AssembledConnections.hpp
 	opm/flowdiagnostics/utility/RandomVector.hpp
 	)

--- a/opm/flowdiagnostics/reorder/tarjan.c
+++ b/opm/flowdiagnostics/reorder/tarjan.c
@@ -34,21 +34,21 @@ enum VertexMark { DONE = -2, REMAINING = -1 };
 
 struct TarjanWorkSpace
 {
-    size_t nvert;
+    size_t nvert;               /**< Number of vertices */
 
-    int *status;
-    int *link;
-    int *time;
+    int *status;                /**< Vertex processing status */
+    int *link;                  /**< Vertex low-link */
+    int *time;                  /**< Vertex DFS discovery time */
 };
 
 struct TarjanSCCResult
 {
-    size_t  ncomp;
-    size_t *start;
-    int    *vert;
+    size_t  ncomp;              /**< Running number of SCCs */
+    size_t *start;              /**< SCC start pointers (CSR) */
+    int    *vert;               /**< SCC contents (CSR format) */
 
-    size_t *vstack, *vstart;
-    int    *cstack, *cstart;
+    size_t *vstack, *vstart;    /**< Vertex stack (reuse 'start') */
+    int    *cstack, *cstart;    /**< Component stack (reuse 'vert') */
 };
 
 static void

--- a/opm/flowdiagnostics/reorder/tarjan.c
+++ b/opm/flowdiagnostics/reorder/tarjan.c
@@ -221,13 +221,16 @@ tarjan_initialise(struct TarjanWorkSpace *work,
 }
 
 static void
-tarjan_local(const int              *ia,
+tarjan_local(const size_t            start,
+             const int              *ia,
              const int              *ja,
              struct TarjanWorkSpace *work,
              struct TarjanSCCResult *scc)
 {
     int    time;
     size_t c;
+
+    push(scc->vstack) = start;
 
     time = 0;
 
@@ -238,6 +241,8 @@ tarjan_local(const int              *ia,
         assert (work->status[c] >= -2);
 
         if (work->status[c] == REMAINING) {
+            /* Discover() writes to work->status[c] */
+
             discover_vertex(c, ia, &time, work, scc);
         }
 
@@ -278,9 +283,7 @@ tarjan_global(const size_t            nv,
             continue;
         }
 
-        push(scc->vstack) = seed;
-
-        tarjan_local(ia, ja, work, scc);
+        tarjan_local(seed, ia, ja, work, scc);
     }
 }
 

--- a/opm/flowdiagnostics/reorder/tarjan.c
+++ b/opm/flowdiagnostics/reorder/tarjan.c
@@ -480,6 +480,45 @@ tarjan(const int  nv,
     return scc;
 }
 
+struct TarjanSCCResult *
+tarjan_reachable_sccs(const size_t            nv,
+                      const int              *ia,
+                      const int              *ja,
+                      const size_t            nstart,
+                      const int              *start_pts,
+                      struct TarjanWorkSpace *work)
+{
+    size_t                  i, start;
+    struct TarjanSCCResult *scc;
+
+    assert ((work != NULL) && "Work-space must be non-NULL");
+    assert ((work->nvert >= nv) &&
+            "Work-space must be large enough to accommodate graph");
+
+#if defined(NDEBUG)
+    /* Suppress 'unused argument' diagnostic ('nv' only in assert()) */
+    (void) nv;
+#endif  /* defined(NDEBUG) */
+
+    scc = allocate_scc_result(work->nvert);
+
+    if (scc != NULL) {
+        tarjan_initialise(work, scc);
+
+        for (i = 0; i < nstart; i++) {
+            start = start_pts[i];
+
+            if (work->status[start] == DONE) {
+                continue;
+            }
+
+            tarjan_local(start, ia, ja, work, scc);
+        }
+    }
+
+    return scc;
+}
+
 int
 tarjan_reverse_sccresult(struct TarjanSCCResult *scc)
 {

--- a/opm/flowdiagnostics/reorder/tarjan.c
+++ b/opm/flowdiagnostics/reorder/tarjan.c
@@ -99,7 +99,7 @@ allocate_scc_result(const size_t nvert)
 
 static void
 capture_scc(const size_t            c,
-            int                    *status,
+            struct TarjanWorkSpace *work,
             struct TarjanSCCResult *scc)
 {
     int    vertex;
@@ -115,9 +115,9 @@ capture_scc(const size_t            c,
     do {
         assert (scc->cstack != scc->cstart);
 
-        /* pop strong component stack */
+        /* Pop strong component stack */
         v = vertex = *++scc->cstack;
-        status[v]  = DONE;
+        work->status[v] = DONE;
 
         /* Capture component vertex in VERT while
          * advancing component end pointer */
@@ -138,7 +138,7 @@ complete_dfs_from_vertex(const size_t            c,
 
     /* Record strong component if 'c' is root */
     if (work->link[c] == work->time[c]) {
-        capture_scc(c, work->status, scc);
+        capture_scc(c, work, scc);
     }
 
     /* Pop 'c' from DFS (vertex) stack */

--- a/opm/flowdiagnostics/reorder/tarjan.c
+++ b/opm/flowdiagnostics/reorder/tarjan.c
@@ -277,8 +277,7 @@ tarjan_find_start(const size_t                  seed,
 }
 
 static void
-tarjan_global(const size_t            nv,
-              const int              *ia,
+tarjan_global(const int              *ia,
               const int              *ja,
               struct TarjanWorkSpace *work,
               struct TarjanSCCResult *scc)
@@ -291,7 +290,7 @@ tarjan_global(const size_t            nv,
     tarjan_initialise(work, scc);
 
     for (start = tarjan_find_start(  0  , work);
-         start < nv;
+         start < work->nvert;
          start = tarjan_find_start(start, work))
     {
         tarjan_local(start, ia, ja, work, scc);
@@ -412,7 +411,7 @@ tarjan(const int  nv,
     }
 
     if (scc != NULL) {
-        tarjan_global(nv, ia, ja, work, scc);
+        tarjan_global(ia, ja, work, scc);
     }
 
     destroy_tarjan_workspace(work);

--- a/opm/flowdiagnostics/reorder/tarjan.c
+++ b/opm/flowdiagnostics/reorder/tarjan.c
@@ -179,7 +179,7 @@ complete_dfs_from_vertex(const size_t            c,
 
 static void
 dfs_from_descendant(const size_t            c,
-                    const int              *ia,
+                    const size_t           *ia,
                     const int              *ja,
                     struct TarjanWorkSpace *work,
                     struct TarjanSCCResult *scc)
@@ -207,13 +207,13 @@ dfs_from_descendant(const size_t            c,
 
 static void
 discover_vertex(const size_t            c,
-                const int              *ia,
+                const size_t           *ia,
                 int                    *time,
                 struct TarjanWorkSpace *work,
                 struct TarjanSCCResult *scc)
 {
     /* number of descendants of c */
-    work->status[c] = ia[c + 1] - ia[c];
+    work->status[c] = (int) (ia[c + 1] - ia[c]);
     work->time[c]   = work->link[c] = (*time)++;
 
     push(scc->cstack) = (int) c;
@@ -254,7 +254,7 @@ tarjan_initialise(struct TarjanWorkSpace *work,
 
 static void
 tarjan_local(const size_t            start,
-             const int              *ia,
+             const size_t           *ia,
              const int              *ja,
              struct TarjanWorkSpace *work,
              struct TarjanSCCResult *scc)
@@ -309,7 +309,7 @@ tarjan_find_start(const size_t                  seed,
 }
 
 static void
-tarjan_global(const int              *ia,
+tarjan_global(const size_t           *ia,
               const int              *ja,
               struct TarjanWorkSpace *work,
               struct TarjanSCCResult *scc)
@@ -363,7 +363,7 @@ swap_scc(struct TarjanSCCResult *scc1,
  * ====================================================================== */
 
 struct TarjanWorkSpace *
-create_tarjan_workspace(const int nvert)
+create_tarjan_workspace(const size_t nvert)
 {
     struct TarjanWorkSpace *ws, ws0 = { 0 };
 
@@ -452,9 +452,9 @@ tarjan_get_strongcomponent(const struct TarjanSCCResult *scc,
 
 /*--------------------------------------------------------------------*/
 struct TarjanSCCResult *
-tarjan(const int  nv,
-       const int *ia,
-       const int *ja)
+tarjan(const size_t  nv,
+       const size_t *ia,
+       const int    *ja)
 /*--------------------------------------------------------------------*/
 {
     struct TarjanWorkSpace *work = NULL;
@@ -482,7 +482,7 @@ tarjan(const int  nv,
 
 struct TarjanSCCResult *
 tarjan_reachable_sccs(const size_t            nv,
-                      const int              *ia,
+                      const size_t           *ia,
                       const int              *ja,
                       const size_t            nstart,
                       const int              *start_pts,

--- a/opm/flowdiagnostics/reorder/tarjan.c
+++ b/opm/flowdiagnostics/reorder/tarjan.c
@@ -261,6 +261,21 @@ tarjan_local(const size_t            start,
     assert (scc->cstack == scc->cstart);
 }
 
+static size_t
+tarjan_find_start(const size_t                  seed,
+                  const struct TarjanWorkSpace *work)
+{
+    size_t start = seed;
+
+    while ((start < work->nvert) &&
+           (work->status[start] == DONE))
+    {
+        ++start;
+    }
+
+    return start;
+}
+
 static void
 tarjan_global(const size_t            nv,
               const int              *ia,
@@ -268,22 +283,18 @@ tarjan_global(const size_t            nv,
               struct TarjanWorkSpace *work,
               struct TarjanSCCResult *scc)
 {
-    size_t seed;
+    size_t start;
 
     assert ((work != NULL) && "Work array must be non-NULL");
     assert ((scc  != NULL) && "Result array must be non-NULL");
 
     tarjan_initialise(work, scc);
 
-    seed = 0;
-    while (seed < nv)
+    for (start = tarjan_find_start(  0  , work);
+         start < nv;
+         start = tarjan_find_start(start, work))
     {
-        if (work->status[seed] == DONE) {
-            ++seed;
-            continue;
-        }
-
-        tarjan_local(seed, ia, ja, work, scc);
+        tarjan_local(start, ia, ja, work, scc);
     }
 }
 

--- a/opm/flowdiagnostics/reorder/tarjan.c
+++ b/opm/flowdiagnostics/reorder/tarjan.c
@@ -61,11 +61,7 @@ assign_int_vector(size_t n, const int val, int *v)
     for (i = 0; i < n; i++) { v[i] = val; }
 }
 
-static int
-min(int a, int b)
-{
-    return (a < b) ? a : b;
-}
+#define MIN(a,b) (((a) < (b)) ? (a) : (b))
 
 /* Stack grows to lower addresses */
 #define peek(stack) (*((stack) + 1))
@@ -247,7 +243,7 @@ tarjan(int                     nv,
                 if (stack != work->stack) {
                     v = peek(stack);
 
-                    link[v] = min(link[v], link[c]);
+                    link[v] = MIN(link[v], link[c]);
                 }
             }
 
@@ -265,7 +261,7 @@ tarjan(int                     nv,
                     push(stack) = child;
                 }
                 else if (status[child] >= 0) {
-                    link[c] = min(link[c], time[child]);
+                    link[c] = MIN(link[c], time[child]);
                 }
                 else {
                     assert(status[child] == DONE);

--- a/opm/flowdiagnostics/reorder/tarjan.h
+++ b/opm/flowdiagnostics/reorder/tarjan.h
@@ -158,6 +158,32 @@ tarjan(const int  nv,
        const int *ia,
        const int *ja);
 
+/**
+ * Reverse order of SCCs represented by result set.
+ *
+ * Maintain order of vertices within each strong component.
+ *
+ * If successful, invalidates any TarjanComponent data held by caller.
+ *
+ * If unsuccessful, the original component order is maintained in the input
+ * argument.  In this case, the requested order can be obtained by
+ * traversing the linear component IDs in reverse using accessor function
+ * tarjan_get_strongcomponent().
+ *
+ * \param[in,out] scc On input, collection of strongly connected components
+ *                    obtained from a previous call to function tarjan().
+ *                    On output, reordered collection of SCCs such that
+ *                    linear access in ascending order of component IDs
+ *                    accesses the original strong components in reverse
+ *                    order.
+ *
+ * \return Whether or not the components could be reversed.  One (true) if
+ * order reversal successful and zero (false) otherwise--typically due to
+ * failure to allocate internal resources for operation.
+ */
+int
+tarjan_reverse_sccresult(struct TarjanSCCResult *scc);
+
 #ifdef __cplusplus
 }
 #endif  /* __cplusplus */

--- a/opm/flowdiagnostics/reorder/tarjan.h
+++ b/opm/flowdiagnostics/reorder/tarjan.h
@@ -28,7 +28,7 @@ SOFTWARE.
  * Run-time complexity is \f$O(|V| + |E|)\f$.
  *
  * The implementation is based on
- * "http://en.wikipedia.org/wiki/Tarjan's_strongly_connected_components_algorithm".
+ * http://en.wikipedia.org/wiki/Tarjan's_strongly_connected_components_algorithm
  */
 
 #ifndef TARJAN_H_INCLUDED
@@ -40,14 +40,41 @@ SOFTWARE.
 extern "C" {
 #endif  /* __cplusplus */
 
+/**
+ * Abstract datatype providing backing store for working dataset in SCC
+ * processing.
+ *
+ * Intentionally incomplete.
+ */
 struct TarjanWorkSpace;
 
+/**
+ * Abstract datatype providing backing store for SCC result data.
+ *
+ * Intentionally incomplete.
+ */
 struct TarjanSCCResult;
 
+/**
+ * Contents of single strong component.
+ *
+ * Essentially a reference type.
+ */
 struct TarjanComponent
 {
+    /**
+     * Number of vertices in component.
+     */
     size_t  size;
-    int    *vertex;
+
+    /**
+     * IDs of vertices in strong component.  Non-owning pointer.  The
+     * vertices of this component are
+     * \code
+     *   vertex[0 .. size-1]
+     * \endcode
+     */
+    const int *vertex;
 };
 
 /**
@@ -72,12 +99,37 @@ create_tarjan_workspace(const int nvert);
 void
 destroy_tarjan_workspace(struct TarjanWorkSpace *ws);
 
+/**
+ * Dispose of backing store for SCC result data.
+ *
+ * \param[in,out] scc SCC result data from a previous call to function
+ * tarjan().  Invalid upon return.
+ */
 void
 destroy_tarjan_sccresult(struct TarjanSCCResult *scc);
 
+/**
+ * Retrieve number of strong components in result dataset.
+ *
+ * \param[in] scc Collection of strongly connected components obtained from
+ * a previous call to function tarjan().
+ *
+ * \return Number of strong components in result dataset.
+ */
 size_t
 tarjan_get_numcomponents(const struct TarjanSCCResult *scc);
 
+/**
+ * Get access to single strong component from SCC result dataset.
+ *
+ * \param[in] scc Collection of strongly connected components obtained from
+ * a previous call to function tarjan().
+ *
+ * \param[in] compID Linear ID of single strong component.  Must be in the
+ * range \code [0 .. tarjan_get_numcomponents(scc) - 1] \endcode.
+ *
+ * \return Single strong component corresponding to explicit linear ID.
+ */
 struct TarjanComponent
 tarjan_get_strongcomponent(const struct TarjanSCCResult *scc,
                            const size_t                  compID);
@@ -90,25 +142,16 @@ tarjan_get_strongcomponent(const struct TarjanSCCResult *scc,
  *
  * \param[in] nv Number of graph vertices.
  *
- * \param[in] ia
- * \param[in] ja adjacency matrix for directed graph in compressed sparse row
- *               format: vertex i has directed edges to vertices ja[ia[i]],
- *                ..., ja[ia[i+1]-1].
+ * \param[in] ia CSR sparse matrix start pointers corresponding to out-
  *
- * \param[out] vert Permutation of vertices into topologically sorted
- *                  sequence of strong components (i.e., loops).
- *                  Array of size \c nv.
+ * \param[in] ja CSR sparse matrix representation of out-neighbours in a
+ *               directed graph: vertex \c i has directed edges to vertices
+ *               \code ja[ia[i]], ..., ja[ia[i + 1] - 1] \endcode.
  *
- * \param[out] comp Pointers to start of each strongly connected
- *                  component in vert, the i'th component has vertices
- *                  vert[comp[i]], ..., vert[comp[i+1] - 1].  Array of
- *                  size \code nv + 1 \endcode.
- *
- * \param[out] ncomp Number of strong components.  Pointer to a single
- *                   \c int.
- *
- * \param[out] work Work-space obtained from the call \code
- * create_tarjan_workspace(nv) \endcode.
+ * \return Strong component result dataset.  Owning pointer.  Dispose of
+ * associate memory by calling the destructor destroy_tarjan_sccresult().
+ * Returns \c NULL in case of failure to allocate the result set or internal
+ * work-space.
  */
 struct TarjanSCCResult *
 tarjan(const int  nv,

--- a/opm/flowdiagnostics/reorder/tarjan.h
+++ b/opm/flowdiagnostics/reorder/tarjan.h
@@ -34,11 +34,21 @@ SOFTWARE.
 #ifndef TARJAN_H_INCLUDED
 #define TARJAN_H_INCLUDED
 
+#include <stddef.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif  /* __cplusplus */
 
 struct TarjanWorkSpace;
+
+struct TarjanSCCResult;
+
+struct TarjanComponent
+{
+    size_t  size;
+    int    *vertex;
+};
 
 /**
  * Create work-space for Tarjan algorithm on graph with specified number of
@@ -61,6 +71,16 @@ create_tarjan_workspace(const int nvert);
  */
 void
 destroy_tarjan_workspace(struct TarjanWorkSpace *ws);
+
+void
+destroy_tarjan_sccresult(struct TarjanSCCResult *scc);
+
+size_t
+tarjan_get_numcomponents(const struct TarjanSCCResult *scc);
+
+struct TarjanComponent
+tarjan_get_strongcomponent(const struct TarjanSCCResult *scc,
+                           const size_t                  compID);
 
 /**
  * Compute the strongly connected components of a directed graph,
@@ -90,14 +110,10 @@ destroy_tarjan_workspace(struct TarjanWorkSpace *ws);
  * \param[out] work Work-space obtained from the call \code
  * create_tarjan_workspace(nv) \endcode.
  */
-void
-tarjan(int        nv   ,
-       const int *ia   ,
-       const int *ja   ,
-       int       *vert ,
-       int       *comp ,
-       int       *ncomp,
-       struct TarjanWorkSpace *ws);
+struct TarjanSCCResult *
+tarjan(const int  nv,
+       const int *ia,
+       const int *ja);
 
 #ifdef __cplusplus
 }

--- a/opm/flowdiagnostics/reorder/tarjan.h
+++ b/opm/flowdiagnostics/reorder/tarjan.h
@@ -88,7 +88,7 @@ struct TarjanComponent
  * work-space using function destroy_tarjan_workspace().
  */
 struct TarjanWorkSpace *
-create_tarjan_workspace(const int nvert);
+create_tarjan_workspace(const size_t nvert);
 
 /**
  * Dispose of backing store for intermediate SCC/Tarjan data.
@@ -155,9 +155,9 @@ tarjan_get_strongcomponent(const struct TarjanSCCResult *scc,
  * work-space.
  */
 struct TarjanSCCResult *
-tarjan(const int  nv,
-       const int *ia,
-       const int *ja);
+tarjan(const size_t  nv,
+       const size_t *ia,
+       const int    *ja);
 
 /**
  * Compute the strongly connected components of reachable set in a directed
@@ -192,7 +192,7 @@ tarjan(const int  nv,
  */
 struct TarjanSCCResult *
 tarjan_reachable_sccs(const size_t            nv,
-                      const int              *ia,
+                      const size_t           *ia,
                       const int              *ja,
                       const size_t            nstart,
                       const int              *start_pts,

--- a/opm/flowdiagnostics/reorder/tarjan.h
+++ b/opm/flowdiagnostics/reorder/tarjan.h
@@ -38,6 +38,30 @@ SOFTWARE.
 extern "C" {
 #endif  /* __cplusplus */
 
+struct TarjanWorkSpace;
+
+/**
+ * Create work-space for Tarjan algorithm on graph with specified number of
+ * nodes (vertices).
+ *
+ * \param[in] nvert Number of graph vertices.
+ *
+ * \return Backing store for intermediate data created during SCC
+ * processing.  \c NULL in case of allocation failure.  Dispose of
+ * work-space using function destroy_tarjan_workspace().
+ */
+struct TarjanWorkSpace *
+create_tarjan_workspace(const int nvert);
+
+/**
+ * Dispose of backing store for intermediate SCC/Tarjan data.
+ *
+ * \param[in,out] ws Work-space structure procured in a previous call to
+ * function create_tarjan_workspace().  Invalid upon return.
+ */
+void
+destroy_tarjan_workspace(struct TarjanWorkSpace *ws);
+
 /**
  * Compute the strongly connected components of a directed graph,
  * \f$G(V,E)\f$.
@@ -53,19 +77,18 @@ extern "C" {
  *
  * \param[out] vert Permutation of vertices into topologically sorted
  *                  sequence of strong components (i.e., loops).
- *                  Array of size <CODE>nv</CODE>.
+ *                  Array of size \c nv.
  *
  * \param[out] comp Pointers to start of each strongly connected
  *                  component in vert, the i'th component has vertices
  *                  vert[comp[i]], ..., vert[comp[i+1] - 1].  Array of
- *                  size <CODE>nv + 1</CODE>.
+ *                  size \code nv + 1 \endcode.
  *
  * \param[out] ncomp Number of strong components.  Pointer to a single
- *                   <CODE>int</CODE>.
+ *                   \c int.
  *
- * \param[out] work Pointer to a scratch array represented as a block
- *                  of memory capable of holding <CODE>3 * nv</CODE>
- *                  elements of type <CODE>int</CODE>.
+ * \param[out] work Work-space obtained from the call \code
+ * create_tarjan_workspace(nv) \endcode.
  */
 void
 tarjan(int        nv   ,
@@ -74,7 +97,7 @@ tarjan(int        nv   ,
        int       *vert ,
        int       *comp ,
        int       *ncomp,
-       int       *work );
+       struct TarjanWorkSpace *ws);
 
 #ifdef __cplusplus
 }

--- a/opm/flowdiagnostics/utility/AssembledConnections.cpp
+++ b/opm/flowdiagnostics/utility/AssembledConnections.cpp
@@ -1,0 +1,425 @@
+/*
+  Copyright 2016 SINTEF ICT, Applied Mathematics.
+  Copyright 2016 Statoil ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif // HAVE_CONFIG_H
+
+#include <opm/flowdiagnostics/utility/AssembledConnections.hpp>
+
+#include <algorithm>
+#include <cassert>
+#include <exception>
+#include <iterator>
+#include <stdexcept>
+#include <utility>
+
+// ---------------------------------------------------------------------
+// Class Opm::Utility::AssembledConnections::Connections
+// ---------------------------------------------------------------------
+
+void
+Opm::Utility::AssembledConnections::
+Connections::add(const int i, const int j)
+{
+    i_.push_back(i);
+    j_.push_back(j);
+
+    max_i_ = std::max(max_i_, i_.back());
+    max_j_ = std::max(max_j_, j_.back());
+}
+
+void
+Opm::Utility::AssembledConnections::
+Connections::add(const int i, const int j, const double v)
+{
+    this->add(i, j);
+
+    v_.push_back(v);
+}
+
+void
+Opm::Utility::AssembledConnections::Connections::clear()
+{
+    WeightVector().swap(v_);
+    EntityVector().swap(j_);
+    EntityVector().swap(i_);
+}
+
+bool
+Opm::Utility::AssembledConnections::Connections::empty() const
+{
+    return i_.empty();
+}
+
+bool
+Opm::Utility::AssembledConnections::Connections::isValid() const
+{
+    return (i_.size() == j_.size())
+        && (v_.empty() || (v_.size() == i_.size()));
+}
+
+bool
+Opm::Utility::AssembledConnections::Connections::isWeighted() const
+{
+    return ! v_.empty();
+}
+
+int
+Opm::Utility::AssembledConnections::Connections::maxRow() const
+{
+    return max_i_;
+}
+
+int
+Opm::Utility::AssembledConnections::Connections::maxCol() const
+{
+    return max_j_;
+}
+
+Opm::Utility::AssembledConnections::Connections::EntityVector::size_type
+Opm::Utility::AssembledConnections::Connections::nnz() const
+{
+    return i_.size();
+}
+
+const Opm::Utility::AssembledConnections::Connections::EntityVector&
+Opm::Utility::AssembledConnections::Connections::i() const
+{
+    return i_;
+}
+
+const Opm::Utility::AssembledConnections::Connections::EntityVector&
+Opm::Utility::AssembledConnections::Connections::j() const
+{
+    return j_;
+}
+
+const Opm::Utility::AssembledConnections::Connections::WeightVector&
+Opm::Utility::AssembledConnections::Connections::v() const
+{
+    return v_;
+}
+
+// =====================================================================
+
+// ---------------------------------------------------------------------
+// Class Opm::Utility::AssembledConnections::CSR
+// ---------------------------------------------------------------------
+
+void
+Opm::Utility::AssembledConnections::
+CSR::create(const Connections& conns)
+{
+    assert (!conns.empty() && conns.isValid());
+
+    this->assemble(conns);
+
+    this->sort();
+
+    // Must be called *after* sort().
+    this->condenseDuplicates();
+
+    if (conns.isWeighted()) {
+        this->accumulateConnWeights(conns.v());
+    }
+}
+
+const Opm::Utility::AssembledConnections::Start&
+Opm::Utility::AssembledConnections::CSR::ia() const
+{
+    return ia_;
+}
+
+const Opm::Utility::AssembledConnections::Neighbours&
+Opm::Utility::AssembledConnections::CSR::ja() const
+{
+    return ja_;
+}
+
+const Opm::Utility::AssembledConnections::ConnWeight&
+Opm::Utility::AssembledConnections::CSR::sa() const
+{
+    return sa_;
+}
+
+void
+Opm::Utility::AssembledConnections::
+CSR::assemble(const Connections& conns)
+{
+    {
+        const auto numRows = conns.maxRow() + 1;
+
+        this->accumulateRowEntries(numRows, conns.i());
+    }
+
+    this->createGraph(conns.i(), conns.j());
+
+    this->numRows_ = conns.maxRow() + 1;
+    this->numCols_ = conns.maxCol() + 1;
+}
+
+void
+Opm::Utility::AssembledConnections::CSR::sort()
+{
+    // Transposition is, effectively, a linear time bucket insert, so
+    // transposing the structure twice creates a structure with colum
+    // indices in (ascendingly) sorted order.
+
+    this->transpose();
+    this->transpose();
+}
+
+void
+Opm::Utility::AssembledConnections::CSR::condenseDuplicates()
+{
+    // Note: Must be called *after* sort().
+
+    const auto colIdx = this->ja_;
+    auto elmIdx       = this->elmIdx_;
+    auto end          = colIdx.begin();
+
+    this->ja_    .clear();
+    this->elmIdx_.clear();
+
+    for (decltype(this->ia_.size())
+             row = 0, numRows = this->ia_.size() - 1;
+         row < numRows; ++row)
+    {
+        auto begin = end;
+
+        std::advance(end, this->ia_[row + 1] - this->ia_[row + 0]);
+
+        const auto q = this->ja_.size();
+
+        this->unique(begin, end);
+
+        this->ia_[row + 0] = q;
+    }
+
+    this->remapElementIndex(std::move(elmIdx));
+
+    // Record final table sizes.
+    this->ia_.back() = this->ja_.size();
+}
+
+void
+Opm::Utility::AssembledConnections::
+CSR::accumulateConnWeights(const std::vector<double>& v)
+{
+    if (v.size() != this->elmIdx_.size()) {
+        throw std::logic_error("Connection Weights must be "
+                               "provided for each connection");
+    }
+
+    this->sa_.assign(this->ja_.size(), 0.0);
+
+    for (decltype(v.size())
+             conn = 0, numConn = v.size();
+         conn < numConn; ++conn)
+    {
+        this->sa_[ this->elmIdx_[conn] ] += v[conn];
+    }
+}
+
+void
+Opm::Utility::AssembledConnections::
+CSR::accumulateRowEntries(const int               numRows,
+                          const std::vector<int>& rowIdx)
+{
+    auto vecIdx = [](const int i)
+    {
+        return static_cast<Start::size_type>(i);
+    };
+
+    this->ia_.assign(vecIdx(numRows) + 1, vecIdx(0));
+
+    for (const auto& row : rowIdx) {
+        this->ia_[vecIdx(row) + 1] += 1;
+    }
+
+    // Note index range: 1..numRows inclusive.
+    for (decltype(this->ia_.size())
+             i = 1, numRows = this->ia_.size() - 1;
+         i <= numRows; ++i)
+    {
+        this->ia_[0] += this->ia_[i];
+        this->ia_[i]  = this->ia_[0] - this->ia_[i];
+    }
+}
+
+void
+Opm::Utility::AssembledConnections::
+CSR::createGraph(const std::vector<int>& rowIdx,
+                 const std::vector<int>& colIdx)
+{
+    assert (this->ia_[0] == rowIdx.size());
+
+    auto vecIdx = [](const int i)
+    {
+        return static_cast<Start::size_type>(i);
+    };
+
+    this->ja_.resize(rowIdx.size());
+
+    this->elmIdx_.clear();
+    this->elmIdx_.reserve(rowIdx.size());
+
+    for (decltype(rowIdx.size())
+             nz = 0, nnz = rowIdx.size();
+         nz < nnz; ++nz)
+    {
+        const auto k = ia_[vecIdx(rowIdx[nz]) + 1] ++;
+
+        this->ja_[k] = colIdx[nz];
+
+        this->elmIdx_.push_back(k);
+    }
+
+    this->ia_[0] = 0;
+}
+
+void
+Opm::Utility::AssembledConnections::CSR::transpose()
+{
+    auto elmIdx = this->elmIdx_;
+
+    {
+        const auto rowIdx = this->expandStartPointers();
+        const auto colIdx = this->ja_;
+
+        this->accumulateRowEntries(this->numCols_, colIdx);
+
+        this->createGraph(colIdx, rowIdx);
+    }
+
+    this->remapElementIndex(std::move(elmIdx));
+
+    std::swap(this->numRows_, this->numCols_);
+}
+
+std::vector<int>
+Opm::Utility::AssembledConnections::
+CSR::expandStartPointers() const
+{
+    auto rowIdx = std::vector<int>{};
+    rowIdx.reserve(this->ia_.back());
+
+    auto row = 0;
+
+    for (decltype(this->ia_.size())
+             i = 0, m = this->ia_.size() - 1; i < m; ++i, ++row)
+    {
+        const auto n = this->ia_[i + 1] - this->ia_[i + 0];
+
+        rowIdx.insert(rowIdx.end(), n, row);
+    }
+
+    return rowIdx;
+}
+
+void
+Opm::Utility::AssembledConnections::
+CSR::unique(Neighbours::const_iterator begin,
+            Neighbours::const_iterator end)
+{
+    // We assume that we're only called *after* sort() whence duplicate
+    // elements appear consecutively in [begin, end).
+    //
+    // Note: This is essentially the same as std::unique(begin, end) save
+    // for the return value.  However, we also record the 'elmIdx_' mapping
+    // to later have the ability to accumulate 'sa_'.
+
+    while (begin != end) {
+        // Note: Order of ja_ and elmIdx_ matters here.
+        this->elmIdx_.push_back(this->ja_.size());
+        this->ja_    .push_back(*begin);
+
+        while ((++begin != end) &&
+               ( *begin == this->ja_.back()))
+        {
+            this->elmIdx_.push_back(this->elmIdx_.back());
+        }
+    }
+}
+
+void
+Opm::Utility::AssembledConnections::CSR::remapElementIndex(Start&& elmIdx)
+{
+    for (auto& i : elmIdx) {
+        i = this->elmIdx_[i];
+    }
+
+    this->elmIdx_.swap(elmIdx);
+}
+
+// =====================================================================
+
+// ---------------------------------------------------------------------
+// Class Opm::Utility::AssembledConnections
+// ---------------------------------------------------------------------
+
+void
+Opm::Utility::AssembledConnections::
+addConnection(const int i,
+              const int j)
+{
+    conns_.add(i, j);
+}
+
+void
+Opm::Utility::AssembledConnections::
+addConnection(const int    i,
+              const int    j,
+              const double v)
+{
+    conns_.add(i, j, v);
+}
+
+void
+Opm::Utility::AssembledConnections::compress()
+{
+    if (conns_.empty() || !conns_.isValid()) {
+        throw std::logic_error("Cannot compress empty or "
+                               "invalid connection list");
+    }
+
+    csr_.create(conns_);
+
+    conns_.clear();
+}
+
+const Opm::Utility::AssembledConnections::Start&
+Opm::Utility::AssembledConnections::startPointers() const
+{
+    return csr_.ia();
+}
+
+const Opm::Utility::AssembledConnections::Neighbours&
+Opm::Utility::AssembledConnections::neighbourhood() const
+{
+    return csr_.ja();
+}
+
+const Opm::Utility::AssembledConnections::ConnWeight&
+Opm::Utility::AssembledConnections::connectionWeight() const
+{
+    return csr_.sa();
+}

--- a/opm/flowdiagnostics/utility/AssembledConnections.hpp
+++ b/opm/flowdiagnostics/utility/AssembledConnections.hpp
@@ -1,0 +1,144 @@
+/*
+  Copyright 2016 SINTEF ICT, Applied Mathematics.
+  Copyright 2016 Statoil ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_ASSEMBLEDCONNECTIONS_HEADER_INCLUDED
+#define OPM_ASSEMBLEDCONNECTIONS_HEADER_INCLUDED
+
+#include <vector>
+
+namespace Opm { namespace Utility {
+
+    class AssembledConnections
+    {
+    public:
+        void addConnection(const int i, const int j);
+        void addConnection(const int i, const int j, const double v);
+
+        void compress();
+
+        using Neighbours = std::vector<int>;
+        using Offset     = Neighbours::size_type;
+        using Start      = std::vector<Offset>;
+        using ConnWeight = std::vector<double>;
+
+        const Start& startPointers() const;
+
+        const Neighbours& neighbourhood() const;
+
+        const ConnWeight& connectionWeight() const;
+
+    private:
+        class Connections
+        {
+        public:
+            using EntityVector = std::vector<int>;
+            using WeightVector = std::vector<double>;
+
+            void add(const int i, const int j);
+            void add(const int i, const int j, const double v);
+
+            void clear();
+
+            bool empty() const;
+
+            bool isValid() const;
+
+            bool isWeighted() const;
+
+            int maxRow() const;
+            int maxCol() const;
+
+            EntityVector::size_type nnz() const;
+
+            const EntityVector& i() const;
+            const EntityVector& j() const;
+            const WeightVector& v() const;
+
+        private:
+            EntityVector i_;
+            EntityVector j_;
+            WeightVector v_;
+
+            int max_i_{ -1 };
+            int max_j_{ -1 };
+        };
+
+        class CSR
+        {
+        public:
+            void create(const Connections& conns);
+
+            const Start&      ia() const;
+            const Neighbours& ja() const;
+            const ConnWeight& sa() const;
+
+        private:
+            Start      ia_;
+            Neighbours ja_;
+            ConnWeight sa_;
+
+            Start      elmIdx_;
+
+            int        numRows_{ 0 };
+            int        numCols_{ 0 };
+
+            // ---------------------------------------------------------
+            // Implementation of create()
+            // ---------------------------------------------------------
+
+            void assemble(const Connections& conns);
+
+            void sort();
+
+            void condenseDuplicates();
+
+            void accumulateConnWeights(const std::vector<double>& v);
+
+            // ---------------------------------------------------------
+            // Implementation of assemble()
+            // ---------------------------------------------------------
+
+            void accumulateRowEntries(const int               numRows,
+                                      const std::vector<int>& rowIdx);
+
+            void createGraph(const std::vector<int>& rowIdx,
+                             const std::vector<int>& colIdx);
+
+            // ---------------------------------------------------------
+            // General utilities
+            // ---------------------------------------------------------
+
+            void transpose();
+
+            std::vector<int> expandStartPointers() const;
+
+            void unique(Neighbours::const_iterator begin,
+                        Neighbours::const_iterator end);
+
+            void remapElementIndex(Start&& elmIdx);
+        };
+
+        Connections conns_;
+        CSR         csr_;
+    };
+
+}} // namespace Opm::Utility
+
+#endif // OPM_ASSEMBLEDCONNECTIONS_HEADER_INCLUDED

--- a/opm/flowdiagnostics/utility/RandomVector.hpp
+++ b/opm/flowdiagnostics/utility/RandomVector.hpp
@@ -18,6 +18,9 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#ifndef OPM_RANDOMVECTOR_HEADER_INCLUDED
+#define OPM_RANDOMVECTOR_HEADER_INCLUDED
+
 #include <memory>
 #include <vector>
 
@@ -54,3 +57,5 @@ namespace Opm
         };
     }
 } // namespace Opm
+
+#endif // OPM_RANDOMVECTOR_HEADER_INCLUDED

--- a/tests/test_assembledconnections.cpp
+++ b/tests/test_assembledconnections.cpp
@@ -1,0 +1,372 @@
+/*
+  Copyright 2016 SINTEF ICT, Applied Mathematics.
+  Copyright 2016 Statoil ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif // HAVE_CONFIG_H
+
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
+
+#define NVERBOSE
+
+#define BOOST_TEST_MODULE TEST_ASSEMBLED_CONNECTIONS
+
+#include <boost/test/unit_test.hpp>
+
+#include <opm/flowdiagnostics/utility/AssembledConnections.hpp>
+
+#include <exception>
+#include <stdexcept>
+
+namespace {
+
+    template <class Collection1, class Collection2>
+    void check_is_close(const Collection1& c1, const Collection2& c2)
+    {
+        BOOST_REQUIRE_EQUAL(c1.size(), c2.size());
+
+        if (! c1.empty()) {
+            auto i1 = c1.begin(), e1 = c1.end();
+            auto i2 = c2.begin();
+
+            for (; i1 != e1; ++i1, ++i2) {
+                BOOST_CHECK_CLOSE(*i1, *i2, 1.0e-10);
+            }
+        }
+    }
+
+} // Namespace Anonymous
+
+BOOST_AUTO_TEST_SUITE(Two_By_Two)
+
+BOOST_AUTO_TEST_CASE (Constructor)
+{
+    auto g = Opm::Utility::AssembledConnections{};
+}
+
+BOOST_AUTO_TEST_CASE (Zero_To_One)
+{
+    auto g = Opm::Utility::AssembledConnections{};
+
+    g.addConnection(0, 1);
+
+    g.compress();
+
+    {
+        const auto start = g.startPointers();
+
+        const auto expect_ia = std::vector<int>{ 0, 1 };
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(start    .begin(), start    .end(),
+                                      expect_ia.begin(), expect_ia.end());
+    }
+
+    {
+        const auto neigh = g.neighbourhood();
+
+        const auto expect_ja = std::vector<int>{ 1 };
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(neigh    .begin(), neigh    .end(),
+                                      expect_ja.begin(), expect_ja.end());
+    }
+}
+
+BOOST_AUTO_TEST_CASE (Zero_To_One_Two)
+{
+    auto g = Opm::Utility::AssembledConnections{};
+
+    g.addConnection(0, 2);
+    g.addConnection(0, 1);
+
+    g.compress();
+
+    {
+        const auto start = g.startPointers();
+
+        const auto expect_ia = std::vector<int>{ 0, 2 };
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(start    .begin(), start    .end(),
+                                      expect_ia.begin(), expect_ia.end());
+    }
+
+    {
+        const auto neigh = g.neighbourhood();
+
+        const auto expect_ja = std::vector<int>{ 1, 2 };
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(neigh    .begin(), neigh    .end(),
+                                      expect_ja.begin(), expect_ja.end());
+    }
+}
+
+BOOST_AUTO_TEST_CASE (Zero_To_One_Two_Duplicate)
+{
+    auto g = Opm::Utility::AssembledConnections{};
+
+    for (auto i = 0, n = 3; i < n; ++i) {
+        g.addConnection(0, 2);
+    }
+
+    g.addConnection(0, 1);
+
+    for (auto i = 0, n = 3; i < n; ++i) {
+        g.addConnection(0, 2);
+    }
+
+    for (auto i = 0, n = 3; i < n; ++i) {
+        g.addConnection(0, 1);
+    }
+
+    g.compress();
+
+    {
+        const auto start = g.startPointers();
+
+        const auto expect_ia = std::vector<int>{ 0, 2 };
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(start    .begin(), start    .end(),
+                                      expect_ia.begin(), expect_ia.end());
+    }
+
+    {
+        const auto neigh = g.neighbourhood();
+
+        const auto expect_ja = std::vector<int>{ 1, 2 };
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(neigh    .begin(), neigh    .end(),
+                                      expect_ja.begin(), expect_ja.end());
+    }
+}
+
+BOOST_AUTO_TEST_CASE (Isolated_Node)
+{
+    auto g = Opm::Utility::AssembledConnections{};
+
+    g.addConnection(2, 0);
+    g.addConnection(0, 2);
+    g.addConnection(0, 0);
+
+    g.compress();
+
+    {
+        const auto start = g.startPointers();
+
+        const auto expect_ia = std::vector<int>{ 0, 2, 2, 3 };
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(start    .begin(), start    .end(),
+                                      expect_ia.begin(), expect_ia.end());
+    }
+
+    {
+        const auto neigh = g.neighbourhood();
+
+        const auto expect_ja = std::vector<int>{ 0, 2, 0 };
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(neigh    .begin(), neigh    .end(),
+                                      expect_ja.begin(), expect_ja.end());
+    }
+}
+
+BOOST_AUTO_TEST_CASE (All_To_All)
+{
+    auto g = Opm::Utility::AssembledConnections{};
+
+    const auto n = 4;
+    for (auto i = 0*n; i < n; ++i) {
+        for (auto j = 0*n; j < n; ++j) {
+            g.addConnection(j, i);
+        }
+    }
+
+    g.compress();
+
+    {
+        const auto start = g.startPointers();
+
+        const auto expect_ia = std::vector<int>{ 0, 4, 8, 12, 16 };
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(start    .begin(), start    .end(),
+                                      expect_ia.begin(), expect_ia.end());
+    }
+
+    {
+        const auto neigh = g.neighbourhood();
+
+        const auto expect_ja = std::vector<int>{
+            0, 1, 2, 3,
+            0, 1, 2, 3,
+            0, 1, 2, 3,
+            0, 1, 2, 3,
+        };
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(neigh    .begin(), neigh    .end(),
+                                      expect_ja.begin(), expect_ja.end());
+    }
+}
+
+BOOST_AUTO_TEST_CASE (All_To_All_Duplicate)
+{
+    auto g = Opm::Utility::AssembledConnections{};
+
+    const auto n = 4;
+
+    for (auto k = 0*n; k < n; ++k) {
+        for (auto i = 0*n; i < n; ++i) {
+            for (auto j = 0*n; j < n; ++j) {
+                g.addConnection(i, i);
+                g.addConnection(i, j);
+                g.addConnection(j, i);
+                g.addConnection(j, j);
+            }
+        }
+    }
+
+    g.compress();
+
+    {
+        const auto start = g.startPointers();
+
+        const auto expect_ia = std::vector<int>{ 0, 4, 8, 12, 16 };
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(start    .begin(), start    .end(),
+                                      expect_ia.begin(), expect_ia.end());
+    }
+
+    {
+        const auto neigh = g.neighbourhood();
+
+        const auto expect_ja = std::vector<int>{
+            0, 1, 2, 3,
+            0, 1, 2, 3,
+            0, 1, 2, 3,
+            0, 1, 2, 3,
+        };
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(neigh    .begin(), neigh    .end(),
+                                      expect_ja.begin(), expect_ja.end());
+    }
+}
+
+BOOST_AUTO_TEST_CASE (Weighted_Graph_Single)
+{
+    auto g = Opm::Utility::AssembledConnections{};
+
+    g.addConnection(0, 2,   0.2);
+    g.addConnection(0, 1, - 0.1);
+
+    g.addConnection(1, 3,  13.0);
+
+    g.addConnection(2, 3, -23.0);
+
+    g.compress();
+
+    {
+        const auto start = g.startPointers();
+
+        const auto expect_ia = std::vector<int>{ 0, 2, 3, 4 };
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(start    .begin(), start    .end(),
+                                      expect_ia.begin(), expect_ia.end());
+    }
+
+    {
+        const auto neigh = g.neighbourhood();
+
+        const auto expect_ja = std::vector<int>{ 1, 2, 3, 3 };
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(neigh    .begin(), neigh    .end(),
+                                      expect_ja.begin(), expect_ja.end());
+    }
+
+    {
+        const auto w = g.connectionWeight();
+
+        const auto expect_w = std::vector<double>{
+            - 0.1, 0.2,
+             13.0,
+            -23.0,
+        };
+
+        check_is_close(w, expect_w);
+    }
+}
+
+BOOST_AUTO_TEST_CASE (Weighted_Graph_Multiple)
+{
+    auto g = Opm::Utility::AssembledConnections{};
+
+    const auto count = 4;
+
+    for (auto i = 0*count; i < count; ++i) {
+        g.addConnection(0, 2,   0.2);
+        g.addConnection(0, 1, - 0.1);
+
+        g.addConnection(1, 3,  13.0);
+
+        g.addConnection(2, 3, -23.0);
+    }
+
+    g.compress();
+
+    {
+        const auto start = g.startPointers();
+
+        const auto expect_ia = std::vector<int>{ 0, 2, 3, 4 };
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(start    .begin(), start    .end(),
+                                      expect_ia.begin(), expect_ia.end());
+    }
+
+    {
+        const auto neigh = g.neighbourhood();
+
+        const auto expect_ja = std::vector<int>{ 1, 2, 3, 3 };
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(neigh    .begin(), neigh    .end(),
+                                      expect_ja.begin(), expect_ja.end());
+    }
+
+    {
+        const auto w = g.connectionWeight();
+
+        const auto expect_w = std::vector<double>{
+            count * (- 0.1), count * 0.2,
+            count *   13.0 ,
+            count * (-23.0),
+        };
+
+        check_is_close(w, expect_w);
+    }
+}
+
+BOOST_AUTO_TEST_CASE (Compress_Invalid_Throw)
+{
+    auto g = Opm::Utility::AssembledConnections{};
+
+    g.addConnection(0, 1);
+    g.addConnection(0, 2, 1.0);
+
+    // Can't mix weighted and unweighted edges.
+    BOOST_CHECK_THROW(g.compress(), std::logic_error);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_tarjan.cpp
+++ b/tests/test_tarjan.cpp
@@ -60,6 +60,23 @@ namespace {
 
     using SCCResult =
         std::unique_ptr<TarjanSCCResult, DestroySCCResult>;
+
+    void check_scc(const std::size_t*     expect_size,
+                   const int*             expect_vert,
+                   const TarjanSCCResult* scc)
+    {
+        const auto ncomp = tarjan_get_numcomponents(scc);
+
+        for (auto comp = 0*ncomp, k = 0*ncomp; comp < ncomp; ++comp) {
+            const auto c = tarjan_get_strongcomponent(scc, comp);
+
+            BOOST_CHECK_EQUAL(c.size, expect_size[comp]);
+
+            for (auto i = 0*c.size; i < c.size; ++i, ++k) {
+                BOOST_CHECK_EQUAL(c.vertex[i], expect_vert[k]);
+            }
+        }
+    }
 } // Anonymous
 
 BOOST_AUTO_TEST_SUITE(Two_By_Two)
@@ -91,25 +108,17 @@ BOOST_AUTO_TEST_CASE (FullySeparable)
     BOOST_CHECK_EQUAL(ncomp, expect_ncomp);
 
     {
-        const int expect_vert[] = { 0, 1, 2, 3 };
+        const std::size_t expect_size[] = { 1, 1, 1, 1 };
+        const int         expect_vert[] = { 0, 1, 2, 3 };
 
-        for (auto comp = 0*ncomp; comp < ncomp; ++comp) {
-            const auto c = tarjan_get_strongcomponent(scc.get(), comp);
-
-            BOOST_CHECK_EQUAL(c.size     , 1);
-            BOOST_CHECK_EQUAL(c.vertex[0], expect_vert[comp]);
-        }
+        check_scc(expect_size, expect_vert, scc.get());
     }
 
     if (tarjan_reverse_sccresult(scc.get())) {
-        const int expect_vert[] = { 3, 2, 1, 0 };
+        const std::size_t expect_size[] = { 1, 1, 1, 1 };
+        const int         expect_vert[] = { 3, 2, 1, 0 };
 
-        for (auto comp = 0*ncomp; comp < ncomp; ++comp) {
-            const auto c = tarjan_get_strongcomponent(scc.get(), comp);
-
-            BOOST_CHECK_EQUAL(c.size     , 1);
-            BOOST_CHECK_EQUAL(c.vertex[0], expect_vert[comp]);
-        }
+        check_scc(expect_size, expect_vert, scc.get());
     }
 }
 
@@ -138,28 +147,20 @@ BOOST_AUTO_TEST_CASE (Loop)
     // test was implemented so the assertion on 'vertex' is only usable as a
     // regression test.
     {
-        const auto c = tarjan_get_strongcomponent(scc.get(), 0);
+        const std::size_t expect_size[] = { nv };
+        const int         expect_vert[] = { 1, 3, 2, 0 };
 
-        BOOST_CHECK_EQUAL(c.size, nv);
-
-        const int expect_vert[] = { 1, 3, 2, 0 };
-
-        BOOST_CHECK_EQUAL_COLLECTIONS(c.vertex   , c.vertex + c.size,
-                                      expect_vert, expect_vert + nv);
+        check_scc(expect_size, expect_vert, scc.get());
     }
 
     if (tarjan_reverse_sccresult(scc.get())) {
         // Reversing order of components maintains internal order of
         // vertices within each component.
-        //
-        const auto c = tarjan_get_strongcomponent(scc.get(), 0);
 
-        BOOST_CHECK_EQUAL(c.size, nv);
+        const std::size_t expect_size[] = { nv };
+        const int         expect_vert[] = { 1, 3, 2, 0 };
 
-        const int expect_vert[] = { 1, 3, 2, 0 };
-
-        BOOST_CHECK_EQUAL_COLLECTIONS(c.vertex   , c.vertex + c.size,
-                                      expect_vert, expect_vert + nv);
+        check_scc(expect_size, expect_vert, scc.get());
     }
 }
 
@@ -188,25 +189,17 @@ BOOST_AUTO_TEST_CASE (DualPath)
     // the flow path in which 1 precedes 3.
 
     {
-        const int expect_vert[] = { 0, 1, 3, 2 };
+        const std::size_t expect_size[] = { 1, 1, 1, 1 };
+        const int         expect_vert[] = { 0, 1, 3, 2 };
 
-        for (auto comp = 0*ncomp; comp < ncomp; ++comp) {
-            const auto c = tarjan_get_strongcomponent(scc.get(), comp);
-
-            BOOST_CHECK_EQUAL(c.size     , 1);
-            BOOST_CHECK_EQUAL(c.vertex[0], expect_vert[comp]);
-        }
+        check_scc(expect_size, expect_vert, scc.get());
     }
 
     if (tarjan_reverse_sccresult(scc.get())) {
-        const int expect_vert[] = { 2, 3, 1, 0 };
+        const std::size_t expect_size[] = { 1, 1, 1, 1 };
+        const int         expect_vert[] = { 2, 3, 1, 0 };
 
-        for (auto comp = 0*ncomp; comp < ncomp; ++comp) {
-            const auto c = tarjan_get_strongcomponent(scc.get(), comp);
-
-            BOOST_CHECK_EQUAL(c.size     , 1);
-            BOOST_CHECK_EQUAL(c.vertex[0], expect_vert[comp]);
-        }
+        check_scc(expect_size, expect_vert, scc.get());
     }
 }
 
@@ -234,25 +227,17 @@ BOOST_AUTO_TEST_CASE (IsolatedFlows)
     // usable as a regression test.
 
     {
-        const int expect_vert[] = { 0, 3, 1, 2 };
+        const std::size_t expect_size[] = { 1, 1, 1, 1 };
+        const int         expect_vert[] = { 0, 3, 1, 2 };
 
-        for (auto comp = 0*ncomp; comp < ncomp; ++comp) {
-            const auto c = tarjan_get_strongcomponent(scc.get(), comp);
-
-            BOOST_CHECK_EQUAL(c.size     , 1);
-            BOOST_CHECK_EQUAL(c.vertex[0], expect_vert[comp]);
-        }
+        check_scc(expect_size, expect_vert, scc.get());
     }
 
     if (tarjan_reverse_sccresult(scc.get())) {
-        const int expect_vert[] = { 2, 1, 3, 0 };
+        const std::size_t expect_size[] = { 1, 1, 1, 1 };
+        const int         expect_vert[] = { 2, 1, 3, 0 };
 
-        for (auto comp = 0*ncomp; comp < ncomp; ++comp) {
-            const auto c = tarjan_get_strongcomponent(scc.get(), comp);
-
-            BOOST_CHECK_EQUAL(c.size     , 1);
-            BOOST_CHECK_EQUAL(c.vertex[0], expect_vert[comp]);
-        }
+        check_scc(expect_size, expect_vert, scc.get());
     }
 }
 
@@ -317,15 +302,7 @@ BOOST_AUTO_TEST_CASE (CentreLoop)
               14, 13, 12, 8,    // 4 ..  7
               4, 3, 2, 1, 0 };  // 8 .. 12
 
-        for (auto comp = 0*ncomp, k = 0*ncomp; comp < ncomp; ++comp) {
-            const auto c = tarjan_get_strongcomponent(scc.get(), comp);
-
-            BOOST_CHECK_EQUAL(c.size, expect_size[comp]);
-
-            for (auto i = 0*c.size; i < c.size; ++i, ++k) {
-                BOOST_CHECK_EQUAL(c.vertex[i], expect_vert[k]);
-            }
-        }
+        check_scc(expect_size, expect_vert, scc.get());
     }
 
     if (tarjan_reverse_sccresult(scc.get())) {
@@ -340,15 +317,7 @@ BOOST_AUTO_TEST_CASE (CentreLoop)
               6, 5, 9, 10,   //  9
               7, 11, 15 };   // 10 .. 12
 
-        for (auto comp = 0*ncomp, k = 0*ncomp; comp < ncomp; ++comp) {
-            const auto c = tarjan_get_strongcomponent(scc.get(), comp);
-
-            BOOST_CHECK_EQUAL(c.size, expect_size[comp]);
-
-            for (auto i = 0*c.size; i < c.size; ++i, ++k) {
-                BOOST_CHECK_EQUAL(c.vertex[i], expect_vert[k]);
-            }
-        }
+        check_scc(expect_size, expect_vert, scc.get());
     }
 }
 
@@ -399,15 +368,7 @@ BOOST_AUTO_TEST_CASE (CentreLoopSource12)
               3, 2, 1, 0,          // 4 ..  7
               4, 8, 14, 13, 12 };  // 8 .. 12
 
-        for (auto comp = 0*ncomp, k = 0*ncomp; comp < ncomp; ++comp) {
-            const auto c = tarjan_get_strongcomponent(scc.get(), comp);
-
-            BOOST_CHECK_EQUAL(c.size, expect_size[comp]);
-
-            for (auto i = 0*c.size; i < c.size; ++i, ++k) {
-                BOOST_CHECK_EQUAL(c.vertex[i], expect_vert[k]);
-            }
-        }
+        check_scc(expect_size, expect_vert, scc.get());
     }
 
     if (tarjan_reverse_sccresult(scc.get())) {
@@ -422,15 +383,7 @@ BOOST_AUTO_TEST_CASE (CentreLoopSource12)
               5, 9, 10, 6,      //  9
               7, 11, 15 };      // 10 .. 12
 
-        for (auto comp = 0*ncomp, k = 0*ncomp; comp < ncomp; ++comp) {
-            const auto c = tarjan_get_strongcomponent(scc.get(), comp);
-
-            BOOST_CHECK_EQUAL(c.size, expect_size[comp]);
-
-            for (auto i = 0*c.size; i < c.size; ++i, ++k) {
-                BOOST_CHECK_EQUAL(c.vertex[i], expect_vert[k]);
-            }
-        }
+        check_scc(expect_size, expect_vert, scc.get());
     }
 }
 

--- a/tests/test_tarjan.cpp
+++ b/tests/test_tarjan.cpp
@@ -32,6 +32,30 @@
 
 #include <opm/flowdiagnostics/reorder/tarjan.h>
 
+#include <memory>
+
+namespace {
+    struct DestroyWorkSpace
+    {
+        void operator()(TarjanWorkSpace* ws);
+    };
+
+    void DestroyWorkSpace::operator()(TarjanWorkSpace* ws)
+    {
+        destroy_tarjan_workspace(ws);
+    }
+
+    std::unique_ptr<TarjanWorkSpace, DestroyWorkSpace>
+    make_workspace(int nvert)
+    {
+        using WorkPtr =
+            std::unique_ptr<TarjanWorkSpace,
+                            DestroyWorkSpace>;
+
+        return WorkPtr{ create_tarjan_workspace(nvert) };
+    }
+} // Anonymous
+
 BOOST_AUTO_TEST_SUITE(Two_By_Two)
 
 // +-----+-----+
@@ -57,9 +81,10 @@ BOOST_AUTO_TEST_CASE (FullySeparable)
     int vert[1*nv + 0] = { 0 };
     int comp[1*nv + 1] = { 0 };
     int ncomp          =   0  ;
-    int work[3*nv + 0] = { 0 };
 
-    tarjan(nv, ia, ja, vert, comp, &ncomp, work);
+    auto work = make_workspace(nv);
+
+    tarjan(nv, ia, ja, vert, comp, &ncomp, work.get());
 
     BOOST_CHECK_EQUAL(ncomp, expect_ncomp);
 
@@ -89,9 +114,10 @@ BOOST_AUTO_TEST_CASE (Loop)
     int vert[1*nv + 0] = { 0 };
     int comp[1*nv + 1] = { -1, -1, -1, -1, -1 };
     int ncomp          =   0  ;
-    int work[3*nv + 0] = { 0 };
 
-    tarjan(nv, ia, ja, vert, comp, &ncomp, work);
+    auto work = make_workspace(nv);
+
+    tarjan(nv, ia, ja, vert, comp, &ncomp, work.get());
 
     BOOST_CHECK_EQUAL(ncomp, 1);
 
@@ -125,9 +151,10 @@ BOOST_AUTO_TEST_CASE (DualPath)
     int vert[1*nv + 0] = { 0 };
     int comp[1*nv + 1] = { -1, -1, -1, -1, -1 };
     int ncomp          =   0  ;
-    int work[3*nv + 0] = { 0 };
 
-    tarjan(nv, ia, ja, vert, comp, &ncomp, work);
+    auto work = make_workspace(nv);
+
+    tarjan(nv, ia, ja, vert, comp, &ncomp, work.get());
 
     BOOST_CHECK_EQUAL(ncomp, expect_ncomp);
 
@@ -159,9 +186,10 @@ BOOST_AUTO_TEST_CASE (IsolatedFlows)
     int vert[1*nv + 0] = { 0 };
     int comp[1*nv + 1] = { -1, -1, -1, -1, -1 };
     int ncomp          =   0  ;
-    int work[3*nv + 0] = { 0 };
 
-    tarjan(nv, ia, ja, vert, comp, &ncomp, work);
+    auto work = make_workspace(nv);
+
+    tarjan(nv, ia, ja, vert, comp, &ncomp, work.get());
 
     BOOST_CHECK_EQUAL(ncomp, expect_ncomp);
 

--- a/tests/test_tarjan.cpp
+++ b/tests/test_tarjan.cpp
@@ -90,13 +90,26 @@ BOOST_AUTO_TEST_CASE (FullySeparable)
 
     BOOST_CHECK_EQUAL(ncomp, expect_ncomp);
 
-    const int expect_vert[] = { 0, 1, 2, 3 };
+    {
+        const int expect_vert[] = { 0, 1, 2, 3 };
 
-    for (auto comp = 0*ncomp; comp < ncomp; ++comp) {
-        const auto c = tarjan_get_strongcomponent(scc.get(), comp);
+        for (auto comp = 0*ncomp; comp < ncomp; ++comp) {
+            const auto c = tarjan_get_strongcomponent(scc.get(), comp);
 
-        BOOST_CHECK_EQUAL(c.size     , 1);
-        BOOST_CHECK_EQUAL(c.vertex[0], expect_vert[comp]);
+            BOOST_CHECK_EQUAL(c.size     , 1);
+            BOOST_CHECK_EQUAL(c.vertex[0], expect_vert[comp]);
+        }
+    }
+
+    if (tarjan_reverse_sccresult(scc.get())) {
+        const int expect_vert[] = { 3, 2, 1, 0 };
+
+        for (auto comp = 0*ncomp; comp < ncomp; ++comp) {
+            const auto c = tarjan_get_strongcomponent(scc.get(), comp);
+
+            BOOST_CHECK_EQUAL(c.size     , 1);
+            BOOST_CHECK_EQUAL(c.vertex[0], expect_vert[comp]);
+        }
     }
 }
 
@@ -120,17 +133,34 @@ BOOST_AUTO_TEST_CASE (Loop)
 
     BOOST_CHECK_EQUAL(ncomp, expect_ncomp);
 
-    const auto c = tarjan_get_strongcomponent(scc.get(), 0);
-
-    BOOST_CHECK_EQUAL(c.size, nv);
-
     // Cell indices within component returned in (essentially) arbitrary
     // order.  This particular order happened to be correct at the time the
     // test was implemented so the assertion on 'vertex' is only usable as a
     // regression test.
-    const int expect_vert[] = { 1, 3, 2, 0 };
-    BOOST_CHECK_EQUAL_COLLECTIONS(c.vertex   , c.vertex + c.size,
-                                  expect_vert, expect_vert + nv);
+    {
+        const auto c = tarjan_get_strongcomponent(scc.get(), 0);
+
+        BOOST_CHECK_EQUAL(c.size, nv);
+
+        const int expect_vert[] = { 1, 3, 2, 0 };
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(c.vertex   , c.vertex + c.size,
+                                      expect_vert, expect_vert + nv);
+    }
+
+    if (tarjan_reverse_sccresult(scc.get())) {
+        // Reversing order of components maintains internal order of
+        // vertices within each component.
+        //
+        const auto c = tarjan_get_strongcomponent(scc.get(), 0);
+
+        BOOST_CHECK_EQUAL(c.size, nv);
+
+        const int expect_vert[] = { 1, 3, 2, 0 };
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(c.vertex   , c.vertex + c.size,
+                                      expect_vert, expect_vert + nv);
+    }
 }
 
 BOOST_AUTO_TEST_CASE (DualPath)
@@ -157,13 +187,26 @@ BOOST_AUTO_TEST_CASE (DualPath)
     // be 0 and 2 respectively.  The order of cells 1 and 3 is determined by
     // the flow path in which 1 precedes 3.
 
-    const int expect_vert[] = { 0, 1, 3, 2 };
+    {
+        const int expect_vert[] = { 0, 1, 3, 2 };
 
-    for (auto comp = 0*ncomp; comp < ncomp; ++comp) {
-        const auto c = tarjan_get_strongcomponent(scc.get(), comp);
+        for (auto comp = 0*ncomp; comp < ncomp; ++comp) {
+            const auto c = tarjan_get_strongcomponent(scc.get(), comp);
 
-        BOOST_CHECK_EQUAL(c.size     , 1);
-        BOOST_CHECK_EQUAL(c.vertex[0], expect_vert[comp]);
+            BOOST_CHECK_EQUAL(c.size     , 1);
+            BOOST_CHECK_EQUAL(c.vertex[0], expect_vert[comp]);
+        }
+    }
+
+    if (tarjan_reverse_sccresult(scc.get())) {
+        const int expect_vert[] = { 2, 3, 1, 0 };
+
+        for (auto comp = 0*ncomp; comp < ncomp; ++comp) {
+            const auto c = tarjan_get_strongcomponent(scc.get(), comp);
+
+            BOOST_CHECK_EQUAL(c.size     , 1);
+            BOOST_CHECK_EQUAL(c.vertex[0], expect_vert[comp]);
+        }
     }
 }
 
@@ -189,13 +232,27 @@ BOOST_AUTO_TEST_CASE (IsolatedFlows)
     // between sinks.  This particular order happened to be correct at the
     // time the test was implemented so the assertion on 'vert' is only
     // usable as a regression test.
-    const int expect_vert[] = { 0, 3, 1, 2 };
 
-    for (auto comp = 0*ncomp; comp < ncomp; ++comp) {
-        const auto c = tarjan_get_strongcomponent(scc.get(), comp);
+    {
+        const int expect_vert[] = { 0, 3, 1, 2 };
 
-        BOOST_CHECK_EQUAL(c.size     , 1);
-        BOOST_CHECK_EQUAL(c.vertex[0], expect_vert[comp]);
+        for (auto comp = 0*ncomp; comp < ncomp; ++comp) {
+            const auto c = tarjan_get_strongcomponent(scc.get(), comp);
+
+            BOOST_CHECK_EQUAL(c.size     , 1);
+            BOOST_CHECK_EQUAL(c.vertex[0], expect_vert[comp]);
+        }
+    }
+
+    if (tarjan_reverse_sccresult(scc.get())) {
+        const int expect_vert[] = { 2, 1, 3, 0 };
+
+        for (auto comp = 0*ncomp; comp < ncomp; ++comp) {
+            const auto c = tarjan_get_strongcomponent(scc.get(), comp);
+
+            BOOST_CHECK_EQUAL(c.size     , 1);
+            BOOST_CHECK_EQUAL(c.vertex[0], expect_vert[comp]);
+        }
     }
 }
 
@@ -248,24 +305,49 @@ BOOST_AUTO_TEST_CASE (CentreLoop)
 
     BOOST_CHECK_EQUAL(ncomp, expect_ncomp);
 
-    const std::size_t expect_size[] =
-        { 1, 1, 1, 4,      // 0 ..  3
-          1, 1, 1, 1,      // 4 ..  7
-          1, 1, 1, 1, 1 }; // 8 .. 12
+    {
+        const std::size_t expect_size[] =
+            { 1, 1, 1, 4,      // 0 ..  3
+              1, 1, 1, 1,      // 4 ..  7
+              1, 1, 1, 1, 1 }; // 8 .. 12
 
-    const int expect_vert[] =
-        { 15, 11, 7,        // 0 ..  2
-          6, 5, 9, 10,      // 3
-          14, 13, 12, 8,    // 4 ..  7
-          4, 3, 2, 1, 0 };  // 8 .. 12
+        const int expect_vert[] =
+            { 15, 11, 7,        // 0 ..  2
+              6, 5, 9, 10,      // 3
+              14, 13, 12, 8,    // 4 ..  7
+              4, 3, 2, 1, 0 };  // 8 .. 12
 
-    for (auto comp = 0*ncomp, k = 0*ncomp; comp < ncomp; ++comp) {
-        const auto c = tarjan_get_strongcomponent(scc.get(), comp);
+        for (auto comp = 0*ncomp, k = 0*ncomp; comp < ncomp; ++comp) {
+            const auto c = tarjan_get_strongcomponent(scc.get(), comp);
 
-        BOOST_CHECK_EQUAL(c.size, expect_size[comp]);
+            BOOST_CHECK_EQUAL(c.size, expect_size[comp]);
 
-        for (auto i = 0*c.size; i < c.size; ++i, ++k) {
-            BOOST_CHECK_EQUAL(c.vertex[i], expect_vert[k]);
+            for (auto i = 0*c.size; i < c.size; ++i, ++k) {
+                BOOST_CHECK_EQUAL(c.vertex[i], expect_vert[k]);
+            }
+        }
+    }
+
+    if (tarjan_reverse_sccresult(scc.get())) {
+        const std::size_t expect_size[] =
+            { 1, 1, 1, 1, 1,    // 0 ..  4
+              1, 1, 1, 1,       // 5 ..  8
+              4, 1, 1, 1 };     // 9 .. 12
+
+        const int expect_vert[] =
+            { 0, 1, 2, 3, 4, //  0 ..  4
+              8, 12, 13, 14, //  5 ..  8
+              6, 5, 9, 10,   //  9
+              7, 11, 15 };   // 10 .. 12
+
+        for (auto comp = 0*ncomp, k = 0*ncomp; comp < ncomp; ++comp) {
+            const auto c = tarjan_get_strongcomponent(scc.get(), comp);
+
+            BOOST_CHECK_EQUAL(c.size, expect_size[comp]);
+
+            for (auto i = 0*c.size; i < c.size; ++i, ++k) {
+                BOOST_CHECK_EQUAL(c.vertex[i], expect_vert[k]);
+            }
         }
     }
 }
@@ -305,24 +387,49 @@ BOOST_AUTO_TEST_CASE (CentreLoopSource12)
 
     BOOST_CHECK_EQUAL(ncomp, expect_ncomp);
 
-    const std::size_t expect_size[] =
-        { 1, 1, 1, 4,      // 0 ..  3
-          1, 1, 1, 1,      // 4 ..  7
-          1, 1, 1, 1, 1 }; // 8 .. 12
+    {
+        const std::size_t expect_size[] =
+            { 1, 1, 1, 4,      // 0 ..  3
+              1, 1, 1, 1,      // 4 ..  7
+              1, 1, 1, 1, 1 }; // 8 .. 12
 
-    const int expect_vert[] =
-        { 15, 11, 7,           // 0 ..  2
-          5, 9, 10, 6,         // 3
-          3, 2, 1, 0,          // 4 ..  7
-          4, 8, 14, 13, 12 };  // 8 .. 12
+        const int expect_vert[] =
+            { 15, 11, 7,           // 0 ..  2
+              5, 9, 10, 6,         // 3
+              3, 2, 1, 0,          // 4 ..  7
+              4, 8, 14, 13, 12 };  // 8 .. 12
 
-    for (auto comp = 0*ncomp, k = 0*ncomp; comp < ncomp; ++comp) {
-        const auto c = tarjan_get_strongcomponent(scc.get(), comp);
+        for (auto comp = 0*ncomp, k = 0*ncomp; comp < ncomp; ++comp) {
+            const auto c = tarjan_get_strongcomponent(scc.get(), comp);
 
-        BOOST_CHECK_EQUAL(c.size, expect_size[comp]);
+            BOOST_CHECK_EQUAL(c.size, expect_size[comp]);
 
-        for (auto i = 0*c.size; i < c.size; ++i, ++k) {
-            BOOST_CHECK_EQUAL(c.vertex[i], expect_vert[k]);
+            for (auto i = 0*c.size; i < c.size; ++i, ++k) {
+                BOOST_CHECK_EQUAL(c.vertex[i], expect_vert[k]);
+            }
+        }
+    }
+
+    if (tarjan_reverse_sccresult(scc.get())) {
+        const std::size_t expect_size[] =
+            { 1, 1, 1, 1, 1,    // 0 ..  4
+              1, 1, 1, 1,       // 5 ..  8
+              4, 1, 1, 1 };     // 9 .. 12
+
+        const int expect_vert[] =
+            { 12, 13, 14, 8, 4, //  0 ..  4
+              0, 1, 2, 3,       //  5 ..  8
+              5, 9, 10, 6,      //  9
+              7, 11, 15 };      // 10 .. 12
+
+        for (auto comp = 0*ncomp, k = 0*ncomp; comp < ncomp; ++comp) {
+            const auto c = tarjan_get_strongcomponent(scc.get(), comp);
+
+            BOOST_CHECK_EQUAL(c.size, expect_size[comp]);
+
+            for (auto i = 0*c.size; i < c.size; ++i, ++k) {
+                BOOST_CHECK_EQUAL(c.vertex[i], expect_vert[k]);
+            }
         }
     }
 }

--- a/tests/test_tarjan.cpp
+++ b/tests/test_tarjan.cpp
@@ -200,3 +200,131 @@ BOOST_AUTO_TEST_CASE (IsolatedFlows)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+
+
+BOOST_AUTO_TEST_SUITE(Four_By_Four)
+
+// +-----+-----+-----+-----+
+// | 12  | 13  | 14  | 15  |
+// +-----+-----+-----+-----+
+// |  8  |  9  | 10  | 11  |
+// +-----+-----+-----+-----+
+// |  4  |  5  |  6  |  7  |
+// +-----+-----+-----+-----+
+// |  0  |  1  |  2  |  3  |
+// +-----+-----+-----+-----+
+
+BOOST_AUTO_TEST_CASE (CentreLoop)
+{
+    //  From -> To
+    //     0 -> [  1, 4 ],
+    //     1 -> [  2, 5 ],
+    //     2 -> [  3, 6 ],
+    //     3 -> [  7 ],
+    //     4 -> [  5, 8 ],
+    //     5 -> [  6 ],
+    //     6 -> [  7, 10 ],
+    //     7 -> [ 11 ],
+    //     8 -> [  9, 12 ],
+    //     9 -> [  5 ],
+    //    10 -> [  9, 11 ],
+    //    11 -> [ 15 ],
+    //    12 -> [ 13 ],
+    //    13 -> [  9, 14 ],
+    //    14 -> [ 10, 15 ],
+    //    15 -> Void (sink cell)
+
+    const int ia[] = {0, 2, 4, 6, 7, 9, 10, 12,
+                      13, 15, 16, 18, 19, 20, 22, 24, 24};
+    const int ja[] = {1, 4, 2, 5, 3, 6, 7, 5, 8, 6, 7, 10, 11,
+                      9, 12, 5, 9, 11, 15, 13, 9, 14, 10, 15};
+
+    const std::size_t nv           = (sizeof ia) / (sizeof ia[0]) - 1;
+    const std::size_t expect_ncomp = 13;
+
+    auto scc = SCCResult{ tarjan(nv, ia, ja) };
+
+    const auto ncomp = tarjan_get_numcomponents(scc.get());
+
+    BOOST_CHECK_EQUAL(ncomp, expect_ncomp);
+
+    const std::size_t expect_size[] =
+        { 1, 1, 1, 4,      // 0 ..  3
+          1, 1, 1, 1,      // 4 ..  7
+          1, 1, 1, 1, 1 }; // 8 .. 12
+
+    const int expect_vert[] =
+        { 15, 11, 7,        // 0 ..  2
+          6, 5, 9, 10,      // 3
+          14, 13, 12, 8,    // 4 ..  7
+          4, 3, 2, 1, 0 };  // 8 .. 12
+
+    for (auto comp = 0*ncomp, k = 0*ncomp; comp < ncomp; ++comp) {
+        const auto c = tarjan_get_strongcomponent(scc.get(), comp);
+
+        BOOST_CHECK_EQUAL(c.size, expect_size[comp]);
+
+        for (auto i = 0*c.size; i < c.size; ++i, ++k) {
+            BOOST_CHECK_EQUAL(c.vertex[i], expect_vert[k]);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE (CentreLoopSource12)
+{
+    //  From -> To
+    //     0 -> [  1 ],
+    //     1 -> [  2 ],
+    //     2 -> [  3, 6 ],
+    //     3 -> [  7 ],
+    //     4 -> [  0, 5 ],
+    //     5 -> [  6 ],
+    //     6 -> [  7, 10 ],
+    //     7 -> [ 11 ],
+    //     8 -> [  4, 9 ],
+    //     9 -> [  5 ],
+    //    10 -> [  9, 11 ],
+    //    11 -> [ 15 ],
+    //    12 -> [  8, 13 ],
+    //    13 -> [ 14 ],
+    //    14 -> [ 10, 15 ],
+    //    15 -> Void (sink cell)
+
+    const int ia[] = {0, 1, 2, 4, 5, 7, 8, 10, 11,
+                      13, 14, 16, 17, 19, 20, 22, 22};
+
+    const int ja[] = {1, 2, 3, 6, 7, 0, 5, 6, 7, 10, 11,
+                      4, 9, 5, 9, 11, 15, 8, 13, 14, 10, 15};
+
+    const std::size_t nv           = (sizeof ia) / (sizeof ia[0]) - 1;
+    const std::size_t expect_ncomp = 13;
+
+    auto scc = SCCResult{ tarjan(nv, ia, ja) };
+
+    const auto ncomp = tarjan_get_numcomponents(scc.get());
+
+    BOOST_CHECK_EQUAL(ncomp, expect_ncomp);
+
+    const std::size_t expect_size[] =
+        { 1, 1, 1, 4,      // 0 ..  3
+          1, 1, 1, 1,      // 4 ..  7
+          1, 1, 1, 1, 1 }; // 8 .. 12
+
+    const int expect_vert[] =
+        { 15, 11, 7,           // 0 ..  2
+          5, 9, 10, 6,         // 3
+          3, 2, 1, 0,          // 4 ..  7
+          4, 8, 14, 13, 12 };  // 8 .. 12
+
+    for (auto comp = 0*ncomp, k = 0*ncomp; comp < ncomp; ++comp) {
+        const auto c = tarjan_get_strongcomponent(scc.get(), comp);
+
+        BOOST_CHECK_EQUAL(c.size, expect_size[comp]);
+
+        for (auto i = 0*c.size; i < c.size; ++i, ++k) {
+            BOOST_CHECK_EQUAL(c.vertex[i], expect_vert[k]);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_tarjan.cpp
+++ b/tests/test_tarjan.cpp
@@ -97,8 +97,8 @@ BOOST_AUTO_TEST_CASE (FullySeparable)
     //
     // Note: (ia,ja) is INFLOW graph whence tarjan() returns SCCs in
     // topological order from sources to sinks.
-    const int ia[] = { 0, 0, 1, 2, 4 };
-    const int ja[] = { 0, 0, 1, 2 };
+    const std::size_t ia[] = { 0, 0, 1, 2, 4 };
+    const int         ja[] = { 0, 0, 1, 2 };
 
     const std::size_t nv           = (sizeof ia) / (sizeof ia[0]) - 1;
     const std::size_t expect_ncomp = 4;
@@ -134,8 +134,8 @@ BOOST_AUTO_TEST_CASE (FullySeparableSparse)
     //
     // Note: (ia,ja) is OUTFLOW graph.  We use tarjan_reverse_sccresult() to
     // access the SCCs in topological order.
-    const int ia[] = { 0, 2, 3, 4, 4 };
-    const int ja[] = { 1, 2, 3, 3 };
+    const std::size_t ia[] = { 0, 2, 3, 4, 4 };
+    const int         ja[] = { 1, 2, 3, 3 };
 
     const int         start_pts[] = { 2 };
     const std::size_t nv          = (sizeof ia) / (sizeof ia[0]) - 1;
@@ -175,8 +175,8 @@ BOOST_AUTO_TEST_CASE (Loop)
     //
     // Note: (ia,ja) is INFLOW graph whence tarjan() returns SCCs in
     // topological order from sources to sinks.
-    const int ia[] = { 0, 1, 2, 3, 4 };
-    const int ja[] = { 2, 0, 3, 1 };
+    const std::size_t ia[] = { 0, 1, 2, 3, 4 };
+    const int         ja[] = { 2, 0, 3, 1 };
 
     const std::size_t nv           = (sizeof ia) / (sizeof ia[0]) - 1;
     const std::size_t expect_ncomp = 1;
@@ -219,8 +219,8 @@ BOOST_AUTO_TEST_CASE (LoopSparse)
     //
     // Note: (ia,ja) is OUTFLOW graph.  We use tarjan_reverse_sccresult() to
     // access the SCCs in topological order.
-    const int ia[] = { 0, 1, 2, 3, 4 };
-    const int ja[] = { 1, 3, 0, 2 };
+    const std::size_t ia[] = { 0, 1, 2, 3, 4 };
+    const int         ja[] = { 1, 3, 0, 2 };
 
     const int         start_pts[] = { 2 };
     const std::size_t nv          = (sizeof ia) / (sizeof ia[0]) - 1;
@@ -266,8 +266,8 @@ BOOST_AUTO_TEST_CASE (DualPath)
     //
     // Note: (ia,ja) is INFLOW graph whence tarjan() returns SCCs in
     // topological order from sources to sinks.
-    const int ia[] = { 0, 0, 2, 3, 4 };
-    const int ja[] = { 0, 0, 3, 1 };
+    const std::size_t ia[] = { 0, 0, 2, 3, 4 };
+    const int         ja[] = { 0, 0, 3, 1 };
 
     const std::size_t nv           = (sizeof ia) / (sizeof ia[0]) - 1;
     const std::size_t expect_ncomp = 4;
@@ -307,8 +307,8 @@ BOOST_AUTO_TEST_CASE (DualPathSparse)
     //
     // Note: (ia,ja) is OUTFLOW graph.  We use tarjan_reverse_sccresult() to
     // access the SCCs in topological order.
-    const int ia[] = { 0, 2, 3, 3, 4 };
-    const int ja[] = { 1, 2, 3, 2 };
+    const std::size_t ia[] = { 0, 2, 3, 3, 4 };
+    const int         ja[] = { 1, 2, 3, 2 };
 
     const int         start_pts[] = { 1 };
     const std::size_t nv          = (sizeof ia) / (sizeof ia[0]) - 1;
@@ -349,8 +349,8 @@ BOOST_AUTO_TEST_CASE (IsolatedFlows)
     //
     // Note: (ia,ja) is INFLOW graph whence tarjan() returns SCCs in
     // topological order from sources to sinks.
-    const int ia[] = { 0, 0, 1, 2, 2 };
-    const int ja[] = { 3, 0 };
+    const std::size_t ia[] = { 0, 0, 1, 2, 2 };
+    const int         ja[] = { 3, 0 };
 
     const std::size_t nv           = (sizeof ia) / (sizeof ia[0]) - 1;
     const std::size_t expect_ncomp = 4;
@@ -389,8 +389,8 @@ BOOST_AUTO_TEST_CASE (IsolatedFlowsSparse)
     //
     // Note: (ia,ja) is OUTFLOW graph.  We use tarjan_reverse_sccresult() to
     // access the SCCs in topological order.
-    const int ia[] = { 0, 1, 1, 1, 2 };
-    const int ja[] = { 2, 1 };
+    const std::size_t ia[] = { 0, 1, 1, 1, 2 };
+    const int         ja[] = { 2, 1 };
 
     const int         start_pts[] = { 3 };
     const std::size_t nv          = (sizeof ia) / (sizeof ia[0]) - 1;
@@ -461,10 +461,10 @@ BOOST_AUTO_TEST_CASE (CentreLoop)
     // Note: (ia,ja) is OUTFLOW graph.  We use tarjan_reverse_sccresult() to
     // access the SCCs in topological order.
 
-    const int ia[] = {0, 2, 4, 6, 7, 9, 10, 12,
-                      13, 15, 16, 18, 19, 20, 22, 24, 24};
-    const int ja[] = {1, 4, 2, 5, 3, 6, 7, 5, 8, 6, 7, 10, 11,
-                      9, 12, 5, 9, 11, 15, 13, 9, 14, 10, 15};
+    const std::size_t ia[] = {0, 2, 4, 6, 7, 9, 10, 12,
+                              13, 15, 16, 18, 19, 20, 22, 24, 24};
+    const int         ja[] = {1, 4, 2, 5, 3, 6, 7, 5, 8, 6, 7, 10, 11,
+                              9, 12, 5, 9, 11, 15, 13, 9, 14, 10, 15};
 
     const std::size_t nv           = (sizeof ia) / (sizeof ia[0]) - 1;
     const std::size_t expect_ncomp = 13;
@@ -529,10 +529,10 @@ BOOST_AUTO_TEST_CASE (CentreLoopSparse)
     // Note: (ia,ja) is OUTFLOW graph.  We use tarjan_reverse_sccresult() to
     // access the SCCs in topological order.
 
-    const int ia[] = {0, 2, 4, 6, 7, 9, 10, 12,
-                      13, 15, 16, 18, 19, 20, 22, 24, 24};
-    const int ja[] = {1, 4, 2, 5, 3, 6, 7, 5, 8, 6, 7, 10, 11,
-                      9, 12, 5, 9, 11, 15, 13, 9, 14, 10, 15};
+    const std::size_t ia[] = {0, 2, 4, 6, 7, 9, 10, 12,
+                              13, 15, 16, 18, 19, 20, 22, 24, 24};
+    const int         ja[] = {1, 4, 2, 5, 3, 6, 7, 5, 8, 6, 7, 10, 11,
+                              9, 12, 5, 9, 11, 15, 13, 9, 14, 10, 15};
 
     const int         start_pts[] = { 5, 12 };
     const std::size_t nv          = (sizeof ia) / (sizeof ia[0]) - 1;
@@ -599,11 +599,11 @@ BOOST_AUTO_TEST_CASE (CentreLoopSource12)
     //    14 -> [ 10, 15 ],
     //    15 -> Void (sink cell)
 
-    const int ia[] = {0, 1, 2, 4, 5, 7, 8, 10, 11,
-                      13, 14, 16, 17, 19, 20, 22, 22};
+    const std::size_t ia[] = {0, 1, 2, 4, 5, 7, 8, 10, 11,
+                              13, 14, 16, 17, 19, 20, 22, 22};
 
-    const int ja[] = {1, 2, 3, 6, 7, 0, 5, 6, 7, 10, 11,
-                      4, 9, 5, 9, 11, 15, 8, 13, 14, 10, 15};
+    const int         ja[] = {1, 2, 3, 6, 7, 0, 5, 6, 7, 10, 11,
+                              4, 9, 5, 9, 11, 15, 8, 13, 14, 10, 15};
 
     const std::size_t nv           = (sizeof ia) / (sizeof ia[0]) - 1;
     const std::size_t expect_ncomp = 13;
@@ -668,11 +668,11 @@ BOOST_AUTO_TEST_CASE (CentreLoopSource12Sparse)
     // Note: (ia,ja) is OUTFLOW graph.  We use tarjan_reverse_sccresult() to
     // access the SCCs in topological order.
 
-    const int ia[] = {0, 1, 2, 4, 5, 7, 8, 10, 11,
-                      13, 14, 16, 17, 19, 20, 22, 22};
+    const std::size_t ia[] = {0, 1, 2, 4, 5, 7, 8, 10, 11,
+                              13, 14, 16, 17, 19, 20, 22, 22};
 
-    const int ja[] = {1, 2, 3, 6, 7, 0, 5, 6, 7, 10, 11,
-                      4, 9, 5, 9, 11, 15, 8, 13, 14, 10, 15};
+    const int         ja[] = {1, 2, 3, 6, 7, 0, 5, 6, 7, 10, 11,
+                              4, 9, 5, 9, 11, 15, 8, 13, 14, 10, 15};
 
     const int         start_pts[] = { 7, 14 };
     const std::size_t nv          = (sizeof ia) / (sizeof ia[0]) - 1;

--- a/tests/test_tarjan.cpp
+++ b/tests/test_tarjan.cpp
@@ -95,6 +95,8 @@ BOOST_AUTO_TEST_CASE (FullySeparable)
     //   1 -> 3
     //   2 -> 3
     //
+    // Note: (ia,ja) is INFLOW graph whence tarjan() returns SCCs in
+    // topological order from sources to sinks.
     const int ia[] = { 0, 0, 1, 2, 4 };
     const int ja[] = { 0, 0, 1, 2 };
 
@@ -122,6 +124,47 @@ BOOST_AUTO_TEST_CASE (FullySeparable)
     }
 }
 
+BOOST_AUTO_TEST_CASE (FullySeparableSparse)
+{
+    // Quarter five-spot pattern:
+    //   0 -> 1
+    //   0 -> 2
+    //   1 -> 3
+    //   2 -> 3
+    //
+    // Note: (ia,ja) is OUTFLOW graph.  We use tarjan_reverse_sccresult() to
+    // access the SCCs in topological order.
+    const int ia[] = { 0, 2, 3, 4, 4 };
+    const int ja[] = { 1, 2, 3, 3 };
+
+    const int         start_pts[] = { 2 };
+    const std::size_t nv          = (sizeof ia) / (sizeof ia[0]) - 1;
+    const std::size_t nstart      = (sizeof start_pts) / (sizeof start_pts[0]);
+
+    auto work = WorkSpace{ create_tarjan_workspace(nv) };
+
+    auto scc = SCCResult{
+        tarjan_reachable_sccs(nv, ia, ja, nstart,
+                              start_pts, work.get())
+    };
+
+    BOOST_CHECK_EQUAL(tarjan_get_numcomponents(scc.get()), 2);
+
+    {
+        const std::size_t expect_size[] = { 1, 1 };
+        const int         expect_vert[] = { 3, 2 };
+
+        check_scc(expect_size, expect_vert, scc.get());
+    }
+
+    if (tarjan_reverse_sccresult(scc.get())) {
+        const std::size_t expect_size[] = { 1, 1 };
+        const int         expect_vert[] = { 2, 3 };
+
+        check_scc(expect_size, expect_vert, scc.get());
+    }
+}
+
 BOOST_AUTO_TEST_CASE (Loop)
 {
     // Circulation:
@@ -130,6 +173,8 @@ BOOST_AUTO_TEST_CASE (Loop)
     //   3 -> 2
     //   2 -> 0
     //
+    // Note: (ia,ja) is INFLOW graph whence tarjan() returns SCCs in
+    // topological order from sources to sinks.
     const int ia[] = { 0, 1, 2, 3, 4 };
     const int ja[] = { 2, 0, 3, 1 };
 
@@ -164,6 +209,53 @@ BOOST_AUTO_TEST_CASE (Loop)
     }
 }
 
+BOOST_AUTO_TEST_CASE (LoopSparse)
+{
+    // Circulation:
+    //   0 -> 1
+    //   1 -> 3
+    //   3 -> 2
+    //   2 -> 0
+    //
+    // Note: (ia,ja) is OUTFLOW graph.  We use tarjan_reverse_sccresult() to
+    // access the SCCs in topological order.
+    const int ia[] = { 0, 1, 2, 3, 4 };
+    const int ja[] = { 1, 3, 0, 2 };
+
+    const int         start_pts[] = { 2 };
+    const std::size_t nv          = (sizeof ia) / (sizeof ia[0]) - 1;
+    const std::size_t nstart      = (sizeof start_pts) / (sizeof start_pts[0]);
+
+    const std::size_t expect_ncomp = 1;
+
+    auto work = WorkSpace{ create_tarjan_workspace(nv) };
+
+    auto scc = SCCResult{
+        tarjan_reachable_sccs(nv, ia, ja, nstart,
+                              start_pts, work.get())
+    };
+
+    BOOST_CHECK_EQUAL(tarjan_get_numcomponents(scc.get()),
+                      expect_ncomp);
+
+    {
+        const std::size_t expect_size[] = { nv };
+        const int         expect_vert[] = { 3, 1, 0, 2 };
+
+        check_scc(expect_size, expect_vert, scc.get());
+    }
+
+    if (tarjan_reverse_sccresult(scc.get())) {
+        // Reversing order of components maintains internal order of
+        // vertices within each component.
+
+        const std::size_t expect_size[] = { nv };
+        const int         expect_vert[] = { 3, 1, 0, 2 };
+
+        check_scc(expect_size, expect_vert, scc.get());
+    }
+}
+
 BOOST_AUTO_TEST_CASE (DualPath)
 {
     // Two flow paths from cell 0 to cell 2:
@@ -172,6 +264,8 @@ BOOST_AUTO_TEST_CASE (DualPath)
     //   3 -> 2
     //   0 -> 2
     //
+    // Note: (ia,ja) is INFLOW graph whence tarjan() returns SCCs in
+    // topological order from sources to sinks.
     const int ia[] = { 0, 0, 2, 3, 4 };
     const int ja[] = { 0, 0, 3, 1 };
 
@@ -203,12 +297,58 @@ BOOST_AUTO_TEST_CASE (DualPath)
     }
 }
 
+BOOST_AUTO_TEST_CASE (DualPathSparse)
+{
+    // Two flow paths from cell 0 to cell 2:
+    //   0 -> 1
+    //   1 -> 3
+    //   3 -> 2
+    //   0 -> 2
+    //
+    // Note: (ia,ja) is OUTFLOW graph.  We use tarjan_reverse_sccresult() to
+    // access the SCCs in topological order.
+    const int ia[] = { 0, 2, 3, 3, 4 };
+    const int ja[] = { 1, 2, 3, 2 };
+
+    const int         start_pts[] = { 1 };
+    const std::size_t nv          = (sizeof ia) / (sizeof ia[0]) - 1;
+    const std::size_t nstart      = (sizeof start_pts) / (sizeof start_pts[0]);
+
+    const std::size_t expect_ncomp = 3;
+
+    auto work = WorkSpace{ create_tarjan_workspace(nv) };
+
+    auto scc = SCCResult{
+        tarjan_reachable_sccs(nv, ia, ja, nstart,
+                              start_pts, work.get())
+    };
+
+    BOOST_CHECK_EQUAL(tarjan_get_numcomponents(scc.get()),
+                      expect_ncomp);
+
+    {
+        const std::size_t expect_size[] = { 1, 1, 1 };
+        const int         expect_vert[] = { 2, 3, 1 };
+
+        check_scc(expect_size, expect_vert, scc.get());
+    }
+
+    if (tarjan_reverse_sccresult(scc.get())) {
+        const std::size_t expect_size[] = { 1, 1, 1 };
+        const int         expect_vert[] = { 1, 3, 2 };
+
+        check_scc(expect_size, expect_vert, scc.get());
+    }
+}
+
 BOOST_AUTO_TEST_CASE (IsolatedFlows)
 {
     // Compartmentalised reservoir with source and sink in each compartment.
     //   0 -> 2
     //   3 -> 1
     //
+    // Note: (ia,ja) is INFLOW graph whence tarjan() returns SCCs in
+    // topological order from sources to sinks.
     const int ia[] = { 0, 0, 1, 2, 2 };
     const int ja[] = { 3, 0 };
 
@@ -236,6 +376,48 @@ BOOST_AUTO_TEST_CASE (IsolatedFlows)
     if (tarjan_reverse_sccresult(scc.get())) {
         const std::size_t expect_size[] = { 1, 1, 1, 1 };
         const int         expect_vert[] = { 2, 1, 3, 0 };
+
+        check_scc(expect_size, expect_vert, scc.get());
+    }
+}
+
+BOOST_AUTO_TEST_CASE (IsolatedFlowsSparse)
+{
+    // Compartmentalised reservoir with source and sink in each compartment.
+    //   0 -> 2
+    //   3 -> 1
+    //
+    // Note: (ia,ja) is OUTFLOW graph.  We use tarjan_reverse_sccresult() to
+    // access the SCCs in topological order.
+    const int ia[] = { 0, 1, 1, 1, 2 };
+    const int ja[] = { 2, 1 };
+
+    const int         start_pts[] = { 3 };
+    const std::size_t nv          = (sizeof ia) / (sizeof ia[0]) - 1;
+    const std::size_t nstart      = (sizeof start_pts) / (sizeof start_pts[0]);
+
+    const std::size_t expect_ncomp = 2;
+
+    auto work = WorkSpace{ create_tarjan_workspace(nv) };
+
+    auto scc = SCCResult{
+        tarjan_reachable_sccs(nv, ia, ja, nstart,
+                              start_pts, work.get())
+    };
+
+    BOOST_CHECK_EQUAL(tarjan_get_numcomponents(scc.get()),
+                      expect_ncomp);
+
+    {
+        const std::size_t expect_size[] = { 1, 1 };
+        const int         expect_vert[] = { 1, 3 };
+
+        check_scc(expect_size, expect_vert, scc.get());
+    }
+
+    if (tarjan_reverse_sccresult(scc.get())) {
+        const std::size_t expect_size[] = { 1, 1 };
+        const int         expect_vert[] = { 3, 1 };
 
         check_scc(expect_size, expect_vert, scc.get());
     }
@@ -275,6 +457,9 @@ BOOST_AUTO_TEST_CASE (CentreLoop)
     //    13 -> [  9, 14 ],
     //    14 -> [ 10, 15 ],
     //    15 -> Void (sink cell)
+    //
+    // Note: (ia,ja) is OUTFLOW graph.  We use tarjan_reverse_sccresult() to
+    // access the SCCs in topological order.
 
     const int ia[] = {0, 2, 4, 6, 7, 9, 10, 12,
                       13, 15, 16, 18, 19, 20, 22, 24, 24};
@@ -316,6 +501,79 @@ BOOST_AUTO_TEST_CASE (CentreLoop)
               8, 12, 13, 14, //  5 ..  8
               6, 5, 9, 10,   //  9
               7, 11, 15 };   // 10 .. 12
+
+        check_scc(expect_size, expect_vert, scc.get());
+    }
+}
+
+BOOST_AUTO_TEST_CASE (CentreLoopSparse)
+{
+    //  From -> To
+    //     0 -> [  1, 4 ],
+    //     1 -> [  2, 5 ],
+    //     2 -> [  3, 6 ],
+    //     3 -> [  7 ],
+    //     4 -> [  5, 8 ],
+    //     5 -> [  6 ],
+    //     6 -> [  7, 10 ],
+    //     7 -> [ 11 ],
+    //     8 -> [  9, 12 ],
+    //     9 -> [  5 ],
+    //    10 -> [  9, 11 ],
+    //    11 -> [ 15 ],
+    //    12 -> [ 13 ],
+    //    13 -> [  9, 14 ],
+    //    14 -> [ 10, 15 ],
+    //    15 -> Void (sink cell)
+    //
+    // Note: (ia,ja) is OUTFLOW graph.  We use tarjan_reverse_sccresult() to
+    // access the SCCs in topological order.
+
+    const int ia[] = {0, 2, 4, 6, 7, 9, 10, 12,
+                      13, 15, 16, 18, 19, 20, 22, 24, 24};
+    const int ja[] = {1, 4, 2, 5, 3, 6, 7, 5, 8, 6, 7, 10, 11,
+                      9, 12, 5, 9, 11, 15, 13, 9, 14, 10, 15};
+
+    const int         start_pts[] = { 5, 12 };
+    const std::size_t nv          = (sizeof ia) / (sizeof ia[0]) - 1;
+    const std::size_t nstart      = (sizeof start_pts) / (sizeof start_pts[0]);
+
+    const std::size_t expect_ncomp = 7;
+
+    auto work = WorkSpace{ create_tarjan_workspace(nv) };
+
+    auto scc = SCCResult{
+        tarjan_reachable_sccs(nv, ia, ja, nstart,
+                              start_pts, work.get())
+    };
+
+    BOOST_CHECK_EQUAL(tarjan_get_numcomponents(scc.get()),
+                      expect_ncomp);
+
+    {
+        const std::size_t expect_size[] =
+            { 1, 1, 1, 4,       // 0 .. 3
+              1, 1, 1 };        // 4 .. 6
+
+        const int expect_vert[] =
+            { 15, 11, 7,        // 0 .. 2
+              9, 10, 6, 5,      // 3
+              14, 13, 12 };     // 4 .. 6
+
+        check_scc(expect_size, expect_vert, scc.get());
+    }
+
+    if (tarjan_reverse_sccresult(scc.get())) {
+        // Order of vertices preserved within strong component.
+
+        const std::size_t expect_size[] =
+            { 1, 1, 1, 4,       // 0 .. 3
+              1, 1, 1 };        // 4 .. 6
+
+        const int expect_vert[] =
+            { 12, 13, 14,       // 0 .. 2
+              9, 10, 6, 5,      // 3
+              7, 11, 15 };      // 4 .. 6
 
         check_scc(expect_size, expect_vert, scc.get());
     }
@@ -382,6 +640,78 @@ BOOST_AUTO_TEST_CASE (CentreLoopSource12)
               0, 1, 2, 3,       //  5 ..  8
               5, 9, 10, 6,      //  9
               7, 11, 15 };      // 10 .. 12
+
+        check_scc(expect_size, expect_vert, scc.get());
+    }
+}
+
+BOOST_AUTO_TEST_CASE (CentreLoopSource12Sparse)
+{
+    //  From -> To
+    //     0 -> [  1 ],
+    //     1 -> [  2 ],
+    //     2 -> [  3, 6 ],
+    //     3 -> [  7 ],
+    //     4 -> [  0, 5 ],
+    //     5 -> [  6 ],
+    //     6 -> [  7, 10 ],
+    //     7 -> [ 11 ],
+    //     8 -> [  4, 9 ],
+    //     9 -> [  5 ],
+    //    10 -> [  9, 11 ],
+    //    11 -> [ 15 ],
+    //    12 -> [  8, 13 ],
+    //    13 -> [ 14 ],
+    //    14 -> [ 10, 15 ],
+    //    15 -> Void (sink cell)
+    //
+    // Note: (ia,ja) is OUTFLOW graph.  We use tarjan_reverse_sccresult() to
+    // access the SCCs in topological order.
+
+    const int ia[] = {0, 1, 2, 4, 5, 7, 8, 10, 11,
+                      13, 14, 16, 17, 19, 20, 22, 22};
+
+    const int ja[] = {1, 2, 3, 6, 7, 0, 5, 6, 7, 10, 11,
+                      4, 9, 5, 9, 11, 15, 8, 13, 14, 10, 15};
+
+    const int         start_pts[] = { 7, 14 };
+    const std::size_t nv          = (sizeof ia) / (sizeof ia[0]) - 1;
+    const std::size_t nstart      = (sizeof start_pts) / (sizeof start_pts[0]);
+
+    const std::size_t expect_ncomp = 5;
+
+    auto work = WorkSpace{ create_tarjan_workspace(nv) };
+
+    auto scc = SCCResult{
+        tarjan_reachable_sccs(nv, ia, ja, nstart,
+                              start_pts, work.get())
+    };
+
+    BOOST_CHECK_EQUAL(tarjan_get_numcomponents(scc.get()),
+                      expect_ncomp);
+
+    {
+        const std::size_t expect_size[] =
+            { 1, 1, 1, 4, 1 };  // 0 .. 4
+
+        const int expect_vert[] =
+            { 15, 11, 7,           // 0 .. 2
+              6, 5, 9, 10,         // 3
+              14 };                // 4
+
+        check_scc(expect_size, expect_vert, scc.get());
+    }
+
+    if (tarjan_reverse_sccresult(scc.get())) {
+        // Order of vertices preserved within each strong component.
+
+        const std::size_t expect_size[] =
+            { 1, 4, 1, 1, 1 };  // 0 .. 4
+
+        const int expect_vert[] =
+            { 14,               // 0
+              6, 5, 9, 10,      // 1
+              7, 11, 15 };      // 2 .. 4
 
         check_scc(expect_size, expect_vert, scc.get());
     }


### PR DESCRIPTION
This change-set refactors the implementation of the `tarjan()` function and exposes a new interface,

``` C
struct TarjanSCCResult *tarjan_reachable_sccs();
```

that enables running the Tarjan SCC algorithm on a reachable subset, identified by its start points, of a directed graph.  This, in turn, is useful in an interactive context in which start points become available as a result of mouse clicks and we need to provide, say, a time-of-flight field on the downstream portion of the model in an expedient fashion.

---

**Update**

This change-set also introduces a new class,

``` C++
class Opm::Utility::AssembledConnections;
```

that simplifies the formation of a CSR representation of a directed or undirected graph.  The user can include individual connections, possibly weighted, separately and call the `compress()` method which forms the CSR representation with column indices in ascendingly sorted order within each row.  Duplicate values are reduced to a single entry and their weights, if applicable, are summed.

This interface is inspired by MATLAB's `sparse` function.
