### PR TITLE
Silence some minor warnings.

### DIFF
--- a/opm/flowdiagnostics/utility/AssembledConnections.cpp
+++ b/opm/flowdiagnostics/utility/AssembledConnections.cpp
@@ -256,9 +256,7 @@ CSR::accumulateRowEntries(const int               numRows,
     }
 
     // Note index range: 1..numRows inclusive.
-    for (decltype(this->ia_.size())
-             i = 1, numRows = this->ia_.size() - 1;
-         i <= numRows; ++i)
+    for (int i = 1; i <= numRows; ++i)
     {
         this->ia_[0] += this->ia_[i];
         this->ia_[i]  = this->ia_[0] - this->ia_[i];

--- a/tests/test_assembledconnections.cpp
+++ b/tests/test_assembledconnections.cpp
@@ -30,7 +30,9 @@
 
 #define BOOST_TEST_MODULE TEST_ASSEMBLED_CONNECTIONS
 
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/flowdiagnostics/utility/AssembledConnections.hpp>
 

--- a/tests/test_tarjan.cpp
+++ b/tests/test_tarjan.cpp
@@ -28,7 +28,9 @@
 
 #define BOOST_TEST_MODULE TarjanImplementationTest
 
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/flowdiagnostics/reorder/tarjan.h>
 


### PR DESCRIPTION
Some boost warnings, and a shadowing warning (now using the numRows parameter directly).
