### PR TITLE
Use explicit row size when forming CSR representation of AssembledConnections

### DIFF
--- a/opm/utility/graph/AssembledConnections.cpp
+++ b/opm/utility/graph/AssembledConnections.cpp
@@ -126,9 +126,16 @@ Opm::AssembledConnections::Connections::v() const
 
 void
 Opm::AssembledConnections::
-CSR::create(const Connections& conns)
+CSR::create(const Connections& conns, const Offset numrows)
 {
-    assert (!conns.empty() && conns.isValid());
+    if (! conns.empty() &&
+        (static_cast<Offset>(conns.maxRow()) >= numrows))
+    {
+        throw std::invalid_argument("Input graph contains more "
+                                    "source vertices than are "
+                                    "implied by explicit size of "
+                                    "adjacency matrix");
+    }
 
     this->assemble(conns);
 
@@ -139,6 +146,13 @@ CSR::create(const Connections& conns)
 
     if (conns.isWeighted()) {
         this->accumulateConnWeights(conns.v());
+    }
+
+    const auto nRows = this->ia().size() - 1;
+    if (nRows < numrows) {
+        this->ia_.insert(this->ia_.end(),
+                         numrows - nRows,
+                         this->ia().back());
     }
 }
 
@@ -244,6 +258,8 @@ Opm::AssembledConnections::
 CSR::accumulateRowEntries(const int               numRows,
                           const std::vector<int>& rowIdx)
 {
+    assert (numRows >= 0);
+
     auto vecIdx = [](const int i)
     {
         return static_cast<Start::size_type>(i);
@@ -256,7 +272,9 @@ CSR::accumulateRowEntries(const int               numRows,
     }
 
     // Note index range: 1..numRows inclusive.
-    for (int i = 1; i <= numRows; ++i)
+    for (Start::size_type
+             i = 1, n = vecIdx(numRows);
+         i <= n; ++i)
     {
         this->ia_[0] += this->ia_[i];
         this->ia_[i]  = this->ia_[0] - this->ia_[i];
@@ -392,14 +410,14 @@ addConnection(const int    i,
 }
 
 void
-Opm::AssembledConnections::compress()
+Opm::AssembledConnections::compress(const std::size_t numRows)
 {
-    if (conns_.empty() || !conns_.isValid()) {
-        throw std::logic_error("Cannot compress empty or "
-                               "invalid connection list");
+    if (! conns_.isValid()) {
+        throw std::logic_error("Cannot compress invalid "
+                               "connection list");
     }
 
-    csr_.create(conns_);
+    csr_.create(conns_, numRows);
 
     conns_.clear();
 }

--- a/opm/utility/graph/AssembledConnections.cpp
+++ b/opm/utility/graph/AssembledConnections.cpp
@@ -422,6 +422,12 @@ Opm::AssembledConnections::compress(const std::size_t numRows)
     conns_.clear();
 }
 
+Opm::AssembledConnections::Offset
+Opm::AssembledConnections::numRows() const
+{
+    return this->startPointers().size() - 1;
+}
+
 const Opm::AssembledConnections::Start&
 Opm::AssembledConnections::startPointers() const
 {

--- a/opm/utility/graph/AssembledConnections.hpp
+++ b/opm/utility/graph/AssembledConnections.hpp
@@ -22,6 +22,8 @@
 #define OPM_ASSEMBLEDCONNECTIONS_HEADER_INCLUDED
 
 #include <opm/utility/graph/AssembledConnectionsIteration.hpp>
+
+#include <cstddef>
 #include <vector>
 
 namespace Opm {
@@ -32,7 +34,24 @@ namespace Opm {
         void addConnection(const int i, const int j);
         void addConnection(const int i, const int j, const double v);
 
-        void compress();
+
+        /// Form CSR adjacency matrix representation of input graph from
+        /// connections established in previous calls to addConnection().
+        ///
+        /// A call to function compress() will fail unless all previously
+        /// established connections have an explicit edge weight (\code
+        /// addConnection(i,j,v) \endcode) or none of those connections have
+        /// an explicit edge weight (\code addConnection(i,j) \endcode).
+        ///
+        /// This method destroys the connection list so if there are
+        /// subsequent calls to method addConnection() then those will
+        /// effectively create a new graph.
+        ///
+        /// \param[in] numRows Number of rows in resulting CSR matrix.  If
+        ///     prior calls to addConnection() supply source entity IDs (row
+        ///     indices) greater than or equal to \p numRows, then method
+        ///     compress() will throw \code std::invalid_argument \endcode.
+        void compress(const std::size_t numRows);
 
         using Neighbours     = std::vector<int>;
         using Offset         = Neighbours::size_type;
@@ -97,7 +116,8 @@ namespace Opm {
         class CSR
         {
         public:
-            void create(const Connections& conns);
+            void create(const Connections& conns,
+                        const Offset       numRows);
 
             const Start&      ia() const;
             const Neighbours& ja() const;

--- a/opm/utility/graph/AssembledConnections.hpp
+++ b/opm/utility/graph/AssembledConnections.hpp
@@ -26,14 +26,35 @@
 #include <cstddef>
 #include <vector>
 
+/// \file
+///
+/// Facility for converting collection of entity pairs or weighted entity
+/// triplets into a sparse (CSR) adjacency matrix representation of a graph.
+/// Supports O(nnz) compression and, if applicable, accumulation of weight
+/// values for repeated entity pairs.
+
 namespace Opm {
 
+    /// Form CSR adjacency matrix representation of graph provided as a list
+    /// of connections between entities, possibly including edge weights.
     class AssembledConnections
     {
     public:
+        /// Add connection between entities.
+        ///
+        /// \param[in] i Primary (source) entity.  Used as row index.
+        ///
+        /// \param[in] j Secondary (sink) entity.  Used as column index.
         void addConnection(const int i, const int j);
-        void addConnection(const int i, const int j, const double v);
 
+        /// Add weighted connection between entities.
+        ///
+        /// \param[in] i Primary (source) entity.  Used as row index.
+        ///
+        /// \param[in] j Secondary (sink) entity.  Used as column index.
+        ///
+        /// \param[in] v Edge weight associated to connection.
+        void addConnection(const int i, const int j, const double v);
 
         /// Form CSR adjacency matrix representation of input graph from
         /// connections established in previous calls to addConnection().
@@ -53,10 +74,20 @@ namespace Opm {
         ///     compress() will throw \code std::invalid_argument \endcode.
         void compress(const std::size_t numRows);
 
-        using Neighbours     = std::vector<int>;
-        using Offset         = Neighbours::size_type;
-        using Start          = std::vector<Offset>;
-        using ConnWeight     = std::vector<double>;
+        /// Representation of neighbouring entities.
+        using Neighbours = std::vector<int>;
+
+        /// Offset into neighbour array.
+        using Offset = Neighbours::size_type;
+
+        /// CSR start pointers.
+        using Start = std::vector<Offset>;
+
+        /// Aggregate connection weights
+        using ConnWeight = std::vector<double>;
+
+        /// Range of neighbours connected to a particular entity.  Includes
+        /// edge weights.
         using CellNeighbours = SimpleIteratorRange<NeighbourhoodIterator>;
 
         /// Retrieve number of rows (source entities) in input graph.
@@ -64,19 +95,39 @@ namespace Opm {
         /// only after calling compress().
         Offset numRows() const;
 
+        /// Retrieve raw CSR start pointers pertaining to current input
+        /// graph.  Only valid after compress() is called.
         const Start& startPointers() const;
 
+        /// Retrieve raw CSR column indices pertaining to current input
+        /// graph.  Only valid after compress() is called.  The neighbours
+        /// of entity \c i are
+        ///
+        ///   \code
+        ///     neighbourhood()[startPointers()[i + 0]] ...
+        ///     neighbourhood()[startPointers()[i + 1] - 1]
+        ///   \endcode
         const Neighbours& neighbourhood() const;
 
+        /// Retrieve accumulated connection weights for each aggregate
+        /// neighbour relation in the adjacency matrix.  Only valid if the
+        /// input graph is specified in terms of explicit edge weights
+        /// (\code addConnection(i,j,v) \endcode).
+        ///
+        /// Weights have the same ordering as the neighbours represented by
+        /// neighbourhood().
         const ConnWeight& connectionWeight() const;
 
         /// Provide a range over a cell neighbourhood.
         ///
         /// Example usage:
+        ///
+        /// \code
         ///    for (const auto& connection : cellNeighbourhood(cell) {
-        ///        // connection.neigbour contains the neigbouring cell
-        ///        // connection.weight   contains the corresponding connection weight
+        ///        // connection.neigbour is the neigbouring cell
+        ///        // connection.weight   is the corresponding connection weight
         ///     }
+        /// \endcode
         ///
         /// This method can only be called if the weight-providing
         /// overload of addConnection() was used to build the instance.

--- a/opm/utility/graph/AssembledConnections.hpp
+++ b/opm/utility/graph/AssembledConnections.hpp
@@ -59,6 +59,11 @@ namespace Opm {
         using ConnWeight     = std::vector<double>;
         using CellNeighbours = SimpleIteratorRange<NeighbourhoodIterator>;
 
+        /// Retrieve number of rows (source entities) in input graph.
+        /// Corresponds to value of argument passed to compress().  Valid
+        /// only after calling compress().
+        Offset numRows() const;
+
         const Start& startPointers() const;
 
         const Neighbours& neighbourhood() const;

--- a/tests/test_assembledconnections.cpp
+++ b/tests/test_assembledconnections.cpp
@@ -73,6 +73,8 @@ BOOST_AUTO_TEST_CASE (Zero_To_One)
 
     g.compress(4);
 
+    BOOST_CHECK_EQUAL(g.numRows(), 4);
+
     {
         const auto start = g.startPointers();
 
@@ -100,6 +102,8 @@ BOOST_AUTO_TEST_CASE (Zero_To_One_Two)
     g.addConnection(0, 1);
 
     g.compress(4);
+
+    BOOST_CHECK_EQUAL(g.numRows(), 4);
 
     {
         const auto start = g.startPointers();
@@ -140,6 +144,8 @@ BOOST_AUTO_TEST_CASE (Zero_To_One_Two_Duplicate)
 
     g.compress(4);
 
+    BOOST_CHECK_EQUAL(g.numRows(), 4);
+
     {
         const auto start = g.startPointers();
 
@@ -173,6 +179,8 @@ BOOST_AUTO_TEST_CASE (No_Out_Edge_From_High_Vertex)
     g.addConnection(2, 3, 1.0);
 
     g.compress(4);
+
+    BOOST_CHECK_EQUAL(g.numRows(), 4);
 
     {
         const auto start = g.startPointers();
@@ -228,6 +236,8 @@ BOOST_AUTO_TEST_CASE (Isolated_Node)
 
     g.compress(3);
 
+    BOOST_CHECK_EQUAL(g.numRows(), 3);
+
     {
         const auto start = g.startPointers();
 
@@ -259,6 +269,8 @@ BOOST_AUTO_TEST_CASE (All_To_All)
     }
 
     g.compress(n);
+
+    BOOST_CHECK_EQUAL(g.numRows(), n);
 
     {
         const auto start = g.startPointers();
@@ -303,6 +315,8 @@ BOOST_AUTO_TEST_CASE (All_To_All_Duplicate)
 
     g.compress(n);
 
+    BOOST_CHECK_EQUAL(g.numRows(), n);
+
     {
         const auto start = g.startPointers();
 
@@ -339,6 +353,8 @@ BOOST_AUTO_TEST_CASE (Weighted_Graph_Single)
     g.addConnection(2, 3, -23.0);
 
     g.compress(4);
+
+    BOOST_CHECK_EQUAL(g.numRows(), 4);
 
     {
         const auto start = g.startPointers();
@@ -401,6 +417,8 @@ BOOST_AUTO_TEST_CASE (Weighted_Graph_Multiple)
     }
 
     g.compress(4);
+
+    BOOST_CHECK_EQUAL(g.numRows(), 4);
 
     {
         const auto start = g.startPointers();


### PR DESCRIPTION
This change-set makes the number of matrix rows in the final CSR form explicit in the `compress()` request.  This, in turn, ensures size consistency in the case of a vertex of high numerical ID having no outbound connections which simplifies client code.  If the client requests a number of rows that is less than or equal to the maximum source entity ID, then the `compress()` call will fail and throw an exception of type [`std::invalid_argument`](http://en.cppreference.com/w/cpp/error/invalid_argument).

We also add support for querying the number of matrix rows after a call to `compress()`.  This query effectively returns the argument that was previously passed to `compress()`.
