### PR TITLE
Time-of-flight solver

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -29,6 +29,7 @@ list (APPEND MAIN_SOURCE_FILES
         opm/flowdiagnostics/ConnectionValues.cpp
         opm/flowdiagnostics/ConnectivityGraph.cpp
         opm/flowdiagnostics/Toolbox.cpp
+        opm/flowdiagnostics/TracerTofSolver.cpp
         opm/utility/graph/tarjan.c
         opm/utility/graph/AssembledConnections.cpp
         opm/utility/numeric/RandomVector.cpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -50,6 +50,7 @@ list (APPEND PUBLIC_HEADER_FILES
         opm/flowdiagnostics/ConnectionValues.hpp
         opm/flowdiagnostics/ConnectivityGraph.hpp
         opm/flowdiagnostics/Toolbox.hpp
+        opm/flowdiagnostics/TracerTofSolver.hpp
         opm/utility/graph/AssembledConnections.hpp
         opm/utility/graph/AssembledConnectionsIteration.hpp
         opm/utility/numeric/RandomVector.hpp

--- a/opm/flowdiagnostics/Toolbox.cpp
+++ b/opm/flowdiagnostics/Toolbox.cpp
@@ -312,8 +312,9 @@ Toolbox::Impl::buildAssembledConnections()
             prod_conn_.addConnection(cells.first, cells.second, -connection_flux);
         }
     }
-    inj_conn_.compress();
-    prod_conn_.compress();
+    const int num_cells = g_.numCells();
+    inj_conn_.compress(num_cells);
+    prod_conn_.compress(num_cells);
 
     // Mark as built (until flux changed).
     conn_built_ = true;

--- a/opm/flowdiagnostics/Toolbox.cpp
+++ b/opm/flowdiagnostics/Toolbox.cpp
@@ -243,7 +243,6 @@ Toolbox::Impl::injDiag(const StartCells& start)
         buildAssembledConnections();
     }
 
-    using SampleSize = RandomVector::Size;
     using Soln       = Solution::Impl;
     using ToF        = Soln::TimeOfFlight;
     using Conc       = Soln::Concentration;
@@ -271,7 +270,6 @@ Toolbox::Impl::prodDiag(const StartCells& start)
         buildAssembledConnections();
     }
 
-    using SampleSize = RandomVector::Size;
     using Soln       = Solution::Impl;
     using ToF        = Soln::TimeOfFlight;
     using Conc       = Soln::Concentration;

--- a/opm/flowdiagnostics/Toolbox.cpp
+++ b/opm/flowdiagnostics/Toolbox.cpp
@@ -39,28 +39,6 @@
 
 #include <opm/utility/numeric/RandomVector.hpp>
 
-namespace { namespace Mock {
-
-    std::vector<double>
-    FieldValue(const std::vector<double>::size_type n,
-               const double mean, const double stdev)
-    {
-        static Opm::RandomVector genRandom{};
-
-        return genRandom.normal(n, mean, stdev);
-    }
-
-    std::vector<int>
-    Index(const std::vector<double>::size_type n,
-          const int maxIdx)
-    {
-        static Opm::RandomVector genRandom{};
-
-        return genRandom.index(n, maxIdx);
-    }
-
-}} // namespace (anonymous)::Mock
-
 
 namespace Opm
 {
@@ -302,43 +280,13 @@ Toolbox::Impl::prodDiag(const StartCells& start)
 
     SolnPtr x(new Soln());
 
-    const auto avgToF = 20.0e3;
-    const auto stdToF = 500.0;
+    TracerTofSolver solver(prod_conn_, pvol_);
+    x->assignToF(solver.solveGlobal(start.points));
 
-    x->assignToF(Mock::FieldValue(g_.numCells(), avgToF, stdToF));
-
-    for (const auto& pt : start.points)
-    {
-        const auto npts = static_cast<SampleSize>
-            (std::distance(pt.begin(), pt.end()));
-
-        const auto n = std::min(
-            { npts, g_.numCells(), static_cast<SampleSize>(100) }
-        );
-
-        const auto idx = Mock::Index(n, g_.numCells() - 1);
-
-        {
-            const auto tof = Mock::FieldValue(n, avgToF, stdToF);
-
-            auto val = CellSetValues{ n };
-            for (auto i = 0*n; i < n; ++i) {
-                val.addCellValue(idx[i], tof[i]);
-            }
-
-            x->assign(pt.id(), ToF{ val });
-        }
-
-        {
-            const auto conc = Mock::FieldValue(n, 0.5, 0.15);
-
-            auto val = CellSetValues{ n };
-            for (auto i = 0*n; i < n; ++i) {
-                val.addCellValue(idx[i], conc[i]);
-            }
-
-            x->assign(pt.id(), Conc{ val });
-        }
+    for (const auto& pt : start.points) {
+        auto solution = solver.solveLocal(pt);
+        x->assign(pt.id(), ToF{ solution.tof });
+        x->assign(pt.id(), Conc{ solution.concentration });
     }
 
     return Reverse{ Solution(std::move(x)) };

--- a/opm/flowdiagnostics/TracerTofSolver.cpp
+++ b/opm/flowdiagnostics/TracerTofSolver.cpp
@@ -23,11 +23,9 @@
 #endif // HAVE_CONFIG_H
 
 #include <opm/flowdiagnostics/TracerTofSolver.hpp>
-#include <opm/flowdiagnostics/Toolbox.hpp>
 #include <opm/utility/graph/tarjan.h>
-#include <opm/utility/graph/AssembledConnections.hpp>
 #include <cassert>
-#include <iostream>
+#include <cmath>
 #include <stdexcept>
 
 namespace Opm

--- a/opm/flowdiagnostics/TracerTofSolver.cpp
+++ b/opm/flowdiagnostics/TracerTofSolver.cpp
@@ -1,0 +1,198 @@
+/*
+  Copyright 2016 SINTEF ICT, Applied Mathematics.
+  Copyright 2016 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif // HAVE_CONFIG_H
+
+#include <opm/flowdiagnostics/TracerTofSolver.hpp>
+#include <opm/flowdiagnostics/Toolbox.hpp>
+#include <opm/utility/graph/tarjan.h>
+#include <opm/utility/graph/AssembledConnections.hpp>
+#include <cassert>
+#include <iostream>
+#include <stdexcept>
+
+namespace Opm
+{
+namespace FlowDiagnostics
+{
+
+
+
+    TracerTofSolver::TracerTofSolver(const AssembledConnections& graph,
+                                     const std::vector<double>& pore_volumes)
+        : g_(graph),
+          pv_(pore_volumes)
+    {
+    }
+
+
+
+
+
+    std::vector<double> TracerTofSolver::solveGlobal(const std::vector<CellSet>& all_startsets)
+    {
+        static_cast<void>(all_startsets); // TODO: use to compute tracer.
+
+        // Reset instance variables.
+        const int num_cells = pv_.size();
+        upwind_influx_.clear();
+        upwind_influx_.resize(num_cells, 0.0);
+        upwind_contrib_.clear();
+        upwind_contrib_.resize(num_cells, 0.0);
+        tof_.clear();
+        tof_.resize(num_cells, -1e100);
+        num_multicell_ = 0;
+        max_size_multicell_ = 0;
+        max_iter_multicell_ = 0;
+
+        // Compute topological ordering.
+        computeOrdering();
+
+        // Solve each component.
+        const int num_components = component_starts_.size() - 1;
+        for (int comp = 0; comp < num_components; ++comp) {
+            const int comp_size = component_starts_[comp + 1] - component_starts_[comp];
+            if (comp_size == 1) {
+                solveSingleCell(sequence_[component_starts_[comp]]);
+            } else {
+                solveMultiCell(comp_size, &sequence_[component_starts_[comp]]);
+            }
+        }
+
+        // Return computed time-of-flight.
+        return tof_;
+    }
+
+
+
+
+
+    TracerTofSolver::LocalSolution TracerTofSolver::solveLocal(const CellSet& startset)
+    {
+        static_cast<void>(startset);
+        return LocalSolution{ CellSetValues{}, CellSetValues{} };
+    }
+
+
+
+
+
+    void TracerTofSolver::computeOrdering()
+    {
+        // Compute reverse topological ordering.
+        const size_t num_cells = pv_.size();
+        assert(g_.startPointers().size() == num_cells + 1);
+        struct Deleter { void operator()(TarjanSCCResult* x) { destroy_tarjan_sccresult(x); } };
+        std::unique_ptr<TarjanSCCResult, Deleter>
+            result(tarjan(num_cells, g_.startPointers().data(), g_.neighbourhood().data()));
+
+        // Must reverse ordering, since Tarjan computes reverse ordering.
+        const int ok = tarjan_reverse_sccresult(result.get());
+        if (!ok) {
+            throw std::runtime_error("Failed to reverse topological ordering in TracerTofSolver::computeOrdering()");
+        }
+
+        // Extract data from solution.
+        sequence_.resize(num_cells);
+        const int num_comp = tarjan_get_numcomponents(result.get());
+        component_starts_.resize(num_comp + 1);
+        component_starts_[0] = 0;
+        for (int comp = 0; comp < num_comp; ++comp) {
+            const TarjanComponent tc = tarjan_get_strongcomponent(result.get(), comp);
+            std::copy(tc.vertex, tc.vertex + tc.size, sequence_.begin() + component_starts_[comp]);
+            component_starts_[comp + 1] = component_starts_[comp] + tc.size;
+        }
+        assert(component_starts_.back() == int(num_cells));
+    }
+
+
+
+
+
+    void TracerTofSolver::solveSingleCell(const int cell)
+    {
+        // Compute downwind fluxes.
+        double downwind_flux = 0.0;
+        for (const auto& conn : g_.cellNeighbourhood(cell)) {
+            downwind_flux += conn.weight;
+        }
+
+        // If source cell, we have influx not accounted for, and
+        // downwind_flux > upwind_flux_[cell]. However the tof at
+        // the influx (wells typically) is zero, so there is no
+        // contribution. However, we will customary halve the tof
+        // for that cell.
+        // If sink cell, we have outflux not accounted for, and
+        // downwind_flux < upwind_flux_[cell]. In that case we
+        // account for it by assuming incompressibility and making
+        // them equal.
+        downwind_flux = std::max(downwind_flux, upwind_influx_[cell]);
+
+        // Compute tof.
+        tof_[cell] = (pv_[cell] + upwind_contrib_[cell])/downwind_flux;
+
+        // Halve if source (well inflow) cell.
+        if (upwind_influx_[cell] == 0.0) {
+            tof_[cell] = 0.5 * tof_[cell];
+        }
+
+        // Set contribution for my downwind cells (if any).
+        for (const auto& conn : g_.cellNeighbourhood(cell)) {
+            const int downwind_cell = conn.neighbour;
+            const double flux = conn.weight;
+            upwind_influx_[downwind_cell] += flux;
+            upwind_contrib_[downwind_cell] += tof_[cell] * flux;
+        }
+    }
+
+
+
+
+
+    void TracerTofSolver::solveMultiCell(const int num_cells, const int* cells)
+    {
+        ++num_multicell_;
+        max_size_multicell_ = std::max(max_size_multicell_, num_cells);
+        // std::cout << "Multiblock solve with " << num_cells << " cells." << std::endl;
+
+        // Using a Gauss-Seidel approach.
+        double max_delta = 1e100;
+        int num_iter = 0;
+        while (max_delta > gauss_seidel_tol_) {
+            max_delta = 0.0;
+            ++num_iter;
+            for (int ci = 0; ci < num_cells; ++ci) {
+                const int cell = cells[ci];
+                const double tof_before = tof_[cell];
+                solveSingleCell(cell);
+                max_delta = std::max(max_delta, std::fabs(tof_[cell] - tof_before));
+            }
+            // std::cout << "Max delta = " << max_delta << std::endl;
+        }
+        max_iter_multicell_ = std::max(max_iter_multicell_, num_iter);
+    }
+
+
+
+
+} // namespace FlowDiagnostics
+} // namespace Opm

--- a/opm/flowdiagnostics/TracerTofSolver.cpp
+++ b/opm/flowdiagnostics/TracerTofSolver.cpp
@@ -26,6 +26,7 @@
 #include <opm/utility/graph/tarjan.h>
 #include <cassert>
 #include <cmath>
+#include <memory>
 #include <stdexcept>
 
 namespace Opm

--- a/opm/flowdiagnostics/TracerTofSolver.hpp
+++ b/opm/flowdiagnostics/TracerTofSolver.hpp
@@ -21,12 +21,10 @@
 #ifndef OPM_TRACERTOFSOLVER_HEADER_INCLUDED
 #define OPM_TRACERTOFSOLVER_HEADER_INCLUDED
 
-#include <opm/flowdiagnostics/Toolbox.hpp>
-#include <opm/utility/graph/tarjan.h>
+#include <opm/flowdiagnostics/CellSet.hpp>
+#include <opm/flowdiagnostics/CellSetValues.hpp>
 #include <opm/utility/graph/AssembledConnections.hpp>
-#include <cassert>
-#include <iostream>
-#include <stdexcept>
+#include <vector>
 
 namespace Opm
 {

--- a/opm/flowdiagnostics/TracerTofSolver.hpp
+++ b/opm/flowdiagnostics/TracerTofSolver.hpp
@@ -1,5 +1,6 @@
 /*
   Copyright 2016 SINTEF ICT, Applied Mathematics.
+  Copyright 2016 Statoil ASA.
 
   This file is part of the Open Porous Media project (OPM).
 
@@ -52,52 +53,12 @@ namespace FlowDiagnostics
         /// directed asyclic graph) containing the out-fluxes from
         /// each cell, and pore volumes.
         TracerTofSolver(const AssembledConnections& graph,
-                        const std::vector<double>& pore_volumes)
-            : g_(graph),
-              pv_(pore_volumes)
-        {
-        }
-
-
+                        const std::vector<double>& pore_volumes);
 
         /// Compute the global (combining all sources) time-of-flight of each cell.
         ///
         /// TODO: also compute tracer solution.
-        std::vector<double> solveGlobal(const std::vector<CellSet>& all_startsets)
-        {
-            static_cast<void>(all_startsets); // TODO: use to compute tracer.
-
-            // Reset instance variables.
-            const int num_cells = pv_.size();
-            upwind_influx_.clear();
-            upwind_influx_.resize(num_cells, 0.0);
-            upwind_contrib_.clear();
-            upwind_contrib_.resize(num_cells, 0.0);
-            tof_.clear();
-            tof_.resize(num_cells, -1e100);
-            num_multicell_ = 0;
-            max_size_multicell_ = 0;
-            max_iter_multicell_ = 0;
-
-            // Compute topological ordering.
-            computeOrdering();
-
-            // Solve each component.
-            const int num_components = component_starts_.size() - 1;
-            for (int comp = 0; comp < num_components; ++comp) {
-                const int comp_size = component_starts_[comp + 1] - component_starts_[comp];
-                if (comp_size == 1) {
-                    solveSingleCell(sequence_[component_starts_[comp]]);
-                } else {
-                    solveMultiCell(comp_size, &sequence_[component_starts_[comp]]);
-                }
-            }
-
-            // Return computed time-of-flight.
-            return tof_;
-        }
-
-
+        std::vector<double> solveGlobal(const std::vector<CellSet>& all_startsets);
 
         /// Output data struct for solveLocal().
         struct LocalSolution {
@@ -105,20 +66,12 @@ namespace FlowDiagnostics
             CellSetValues concentration;
         };
 
-
-
         /// Compute a local solution tracer and time-of-flight solution.
         ///
         /// Local means that only cells downwind from he startset are considered.
         /// The solution is therefore potentially sparse.
         /// TODO: not implemented!
-        LocalSolution solveLocal(const CellSet& startset)
-        {
-            static_cast<void>(startset);
-            return LocalSolution{ CellSetValues{}, CellSetValues{} };
-        }
-
-
+        LocalSolution solveLocal(const CellSet& startset);
 
     private:
 
@@ -138,96 +91,11 @@ namespace FlowDiagnostics
 
         // --------------  Private methods --------------
 
-        void computeOrdering()
-        {
-            // Compute reverse topological ordering.
-            const size_t num_cells = pv_.size();
-            assert(g_.startPointers().size() == num_cells + 1);
-            struct Deleter { void operator()(TarjanSCCResult* x) { destroy_tarjan_sccresult(x); } };
-            std::unique_ptr<TarjanSCCResult, Deleter>
-                result(tarjan(num_cells, g_.startPointers().data(), g_.neighbourhood().data()));
+        void computeOrdering();
 
-            // Must reverse ordering, since Tarjan computes reverse ordering.
-            const int ok = tarjan_reverse_sccresult(result.get());
-            if (!ok) {
-                throw std::runtime_error("Failed to reverse topological ordering in TracerTofSolver::computeOrdering()");
-            }
+        void solveSingleCell(const int cell);
 
-            // Extract data from solution.
-            sequence_.resize(num_cells);
-            const int num_comp = tarjan_get_numcomponents(result.get());
-            component_starts_.resize(num_comp + 1);
-            component_starts_[0] = 0;
-            for (int comp = 0; comp < num_comp; ++comp) {
-                const TarjanComponent tc = tarjan_get_strongcomponent(result.get(), comp);
-                std::copy(tc.vertex, tc.vertex + tc.size, sequence_.begin() + component_starts_[comp]);
-                component_starts_[comp + 1] = component_starts_[comp] + tc.size;
-            }
-            assert(component_starts_.back() == int(num_cells));
-        }
-
-
-
-        void solveSingleCell(const int cell)
-        {
-            // Compute downwind fluxes.
-            double downwind_flux = 0.0;
-            for (const auto& conn : g_.cellNeighbourhood(cell)) {
-                downwind_flux += conn.weight;
-            }
-
-            // If source cell, we have influx not accounted for, and
-            // downwind_flux > upwind_flux_[cell]. However the tof at
-            // the influx (wells typically) is zero, so there is no
-            // contribution. However, we will customary halve the tof
-            // for that cell.
-            // If sink cell, we have outflux not accounted for, and
-            // downwind_flux < upwind_flux_[cell]. In that case we
-            // account for it by assuming incompressibility and making
-            // them equal.
-            downwind_flux = std::max(downwind_flux, upwind_influx_[cell]);
-
-            // Compute tof.
-            tof_[cell] = (pv_[cell] + upwind_contrib_[cell])/downwind_flux;
-
-            // Halve if source (well inflow) cell.
-            if (upwind_influx_[cell] == 0.0) {
-                tof_[cell] = 0.5 * tof_[cell];
-            }
-
-            // Set contribution for my downwind cells (if any).
-            for (const auto& conn : g_.cellNeighbourhood(cell)) {
-                const int downwind_cell = conn.neighbour;
-                const double flux = conn.weight;
-                upwind_influx_[downwind_cell] += flux;
-                upwind_contrib_[downwind_cell] += tof_[cell] * flux;
-            }
-        }
-
-
-
-        void solveMultiCell(const int num_cells, const int* cells)
-        {
-            ++num_multicell_;
-            max_size_multicell_ = std::max(max_size_multicell_, num_cells);
-            // std::cout << "Multiblock solve with " << num_cells << " cells." << std::endl;
-
-            // Using a Gauss-Seidel approach.
-            double max_delta = 1e100;
-            int num_iter = 0;
-            while (max_delta > gauss_seidel_tol_) {
-                max_delta = 0.0;
-                ++num_iter;
-                for (int ci = 0; ci < num_cells; ++ci) {
-                    const int cell = cells[ci];
-                    const double tof_before = tof_[cell];
-                    solveSingleCell(cell);
-                    max_delta = std::max(max_delta, std::fabs(tof_[cell] - tof_before));
-                }
-                // std::cout << "Max delta = " << max_delta << std::endl;
-            }
-            max_iter_multicell_ = std::max(max_iter_multicell_, num_iter);
-        }
+        void solveMultiCell(const int num_cells, const int* cells);
     };
 
 } // namespace FlowDiagnostics

--- a/opm/flowdiagnostics/TracerTofSolver.hpp
+++ b/opm/flowdiagnostics/TracerTofSolver.hpp
@@ -136,9 +136,8 @@ namespace FlowDiagnostics
             double downwind_flux = 0.0;
             const auto& sp = assembled_conn_.startPointers();
             if (cell < int(sp.size()) - 1) { // TODO: remove test when CRS from AC valid.
-                for (size_t connection_index = sp[cell]; connection_index < sp[cell + 1]; ++connection_index) {
-                    const double flux = assembled_conn_.connectionWeight()[connection_index];
-                    downwind_flux += flux;
+                for (const auto& conn : assembled_conn_.cellNeighbourhood(cell)) {
+                    downwind_flux += conn.weight;
                 }
             }
 
@@ -163,9 +162,9 @@ namespace FlowDiagnostics
 
             // Set contribution for my downwind cells (if any).
             if (cell < int(sp.size()) - 1) { // TODO: remove test when CRS from AC valid.
-                for (size_t connection_index = sp[cell]; connection_index < sp[cell + 1]; ++connection_index) {
-                    const int downwind_cell = assembled_conn_.neighbourhood()[connection_index];
-                    const double flux = assembled_conn_.connectionWeight()[connection_index];
+                for (const auto& conn : assembled_conn_.cellNeighbourhood(cell)) {
+                    const int downwind_cell = conn.neighbour;
+                    const double flux = conn.weight;
                     upwind_influx_[downwind_cell] += flux;
                     upwind_contrib_[downwind_cell] += tof_[cell] * flux;
                 }

--- a/opm/flowdiagnostics/TracerTofSolver.hpp
+++ b/opm/flowdiagnostics/TracerTofSolver.hpp
@@ -20,13 +20,15 @@
 #ifndef OPM_TRACERTOFSOLVER_HEADER_INCLUDED
 #define OPM_TRACERTOFSOLVER_HEADER_INCLUDED
 
-#include <opm/flowdiagnostics/FlowDiagnosticsTool.hpp>
-#include <opm/flowdiagnostics/reorder/tarjan.h>
-#include <opm/flowdiagnostics/utility/AssembledConnections.hpp>
+#include <opm/flowdiagnostics/Toolbox.hpp>
+#include <opm/utility/graph/tarjan.h>
+#include <opm/utility/graph/AssembledConnections.hpp>
 #include <cassert>
 #include <iostream>
 
 namespace Opm
+{
+namespace FlowDiagnostics
 {
 
     class TracerTofSolver
@@ -80,7 +82,7 @@ namespace Opm
             // Create the data structure needed for Tarjan's algorithm.
             const size_t num_cells = g_.numCells();
             const size_t num_connections = g_.numConnections();
-            assembled_conn_ = Utility::AssembledConnections();
+            assembled_conn_ = AssembledConnections();
             for (size_t conn_idx = 0; conn_idx < num_connections; ++conn_idx) {
                 auto cells = g_.connection(conn_idx);
                 const double connection_flux = flux_(ConnectionValues::ConnID{conn_idx},
@@ -180,7 +182,7 @@ namespace Opm
         const ConnectivityGraph& g_;
         const std::vector<double>& pv_;
         const ConnectionValues& flux_;
-        Utility::AssembledConnections assembled_conn_;
+        AssembledConnections assembled_conn_;
         std::vector<int> sequence_;
         std::vector<int> component_starts_;
         std::vector<double> upwind_influx_;
@@ -188,6 +190,7 @@ namespace Opm
         std::vector<double> tof_;
     };
 
+} // namespace FlowDiagnostics
 } // namespace Opm
 
 #endif // OPM_TRACERTOFSOLVER_HEADER_INCLUDED

--- a/opm/flowdiagnostics/TracerTofSolver.hpp
+++ b/opm/flowdiagnostics/TracerTofSolver.hpp
@@ -34,24 +34,23 @@ namespace FlowDiagnostics
     class TracerTofSolver
     {
     public:
-        TracerTofSolver(const ConnectivityGraph& graph,
-                        const std::vector<double>& pore_volumes,
-                        const ConnectionValues& flux)
+        TracerTofSolver(const AssembledConnections& graph,
+                        const std::vector<double>& pore_volumes)
             : g_(graph),
-              pv_(pore_volumes),
-              flux_(flux)
+              pv_(pore_volumes)
         {
         }
 
         std::vector<double> solveGlobal(const std::vector<CellSet>& all_startsets)
         {
             static_cast<void>(all_startsets);
+            const int num_cells = pv_.size();
             upwind_influx_.clear();
-            upwind_influx_.resize(g_.numCells(), 0.0);
+            upwind_influx_.resize(num_cells, 0.0);
             upwind_contrib_.clear();
-            upwind_contrib_.resize(g_.numCells(), 0.0);
+            upwind_contrib_.resize(num_cells, 0.0);
             tof_.clear();
-            tof_.resize(g_.numCells(), -1e100);
+            tof_.resize(num_cells, -1e100);
             computeOrdering();
             const int num_components = component_starts_.size() - 1;
             for (int comp = 0; comp < num_components; ++comp) {
@@ -79,26 +78,11 @@ namespace FlowDiagnostics
     private:
         void computeOrdering()
         {
-            // Create the data structure needed for Tarjan's algorithm.
-            const size_t num_cells = g_.numCells();
-            const size_t num_connections = g_.numConnections();
-            assembled_conn_ = AssembledConnections();
-            for (size_t conn_idx = 0; conn_idx < num_connections; ++conn_idx) {
-                auto cells = g_.connection(conn_idx);
-                const double connection_flux = flux_(ConnectionValues::ConnID{conn_idx},
-                                                     ConnectionValues::PhaseID{0});
-                if (connection_flux > 0.0) {
-                    assembled_conn_.addConnection(cells.first, cells.second, connection_flux);
-                } else {
-                    assembled_conn_.addConnection(cells.second, cells.first, -connection_flux);
-                }
-            }
-            assembled_conn_.compress();
-
             // We might have to pad the start pointers if the last
             // cell(s) did not have outgoing fluxes, to get the
             // traditional format expected by tarjan().
-            auto sp = assembled_conn_.startPointers();
+            const size_t num_cells = pv_.size();
+            auto sp = g_.startPointers();
             if (sp.size() != num_cells + 1) {
                 assert(sp.size() < num_cells + 1);
                 sp.insert(sp.end(), num_cells + 1 - sp.size(), sp.back());
@@ -109,7 +93,7 @@ namespace FlowDiagnostics
             struct Deleter { void operator()(TarjanSCCResult* x) { destroy_tarjan_sccresult(x); } };
             std::unique_ptr<TarjanSCCResult, Deleter> result(tarjan(num_cells,
                                                                     sp.data(),
-                                                                    assembled_conn_.neighbourhood().data()));
+                                                                    g_.neighbourhood().data()));
 
             // Must reverse ordering, since Tarjan computes reverse ordering.
             const int ok = tarjan_reverse_sccresult(result.get());
@@ -134,9 +118,9 @@ namespace FlowDiagnostics
         {
             // Compute downwind fluxes.
             double downwind_flux = 0.0;
-            const auto& sp = assembled_conn_.startPointers();
+            const auto& sp = g_.startPointers();
             if (cell < int(sp.size()) - 1) { // TODO: remove test when CRS from AC valid.
-                for (const auto& conn : assembled_conn_.cellNeighbourhood(cell)) {
+                for (const auto& conn : g_.cellNeighbourhood(cell)) {
                     downwind_flux += conn.weight;
                 }
             }
@@ -162,7 +146,7 @@ namespace FlowDiagnostics
 
             // Set contribution for my downwind cells (if any).
             if (cell < int(sp.size()) - 1) { // TODO: remove test when CRS from AC valid.
-                for (const auto& conn : assembled_conn_.cellNeighbourhood(cell)) {
+                for (const auto& conn : g_.cellNeighbourhood(cell)) {
                     const int downwind_cell = conn.neighbour;
                     const double flux = conn.weight;
                     upwind_influx_[downwind_cell] += flux;
@@ -178,10 +162,8 @@ namespace FlowDiagnostics
             static_cast<void>(cells);
         }
 
-        const ConnectivityGraph& g_;
+        const AssembledConnections& g_;
         const std::vector<double>& pv_;
-        const ConnectionValues& flux_;
-        AssembledConnections assembled_conn_;
         std::vector<int> sequence_;
         std::vector<int> component_starts_;
         std::vector<double> upwind_influx_;

--- a/opm/flowdiagnostics/TracerTofSolver.hpp
+++ b/opm/flowdiagnostics/TracerTofSolver.hpp
@@ -1,0 +1,177 @@
+/*
+  Copyright 2016 SINTEF ICT, Applied Mathematics.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_TRACERTOFSOLVER_HEADER_INCLUDED
+#define OPM_TRACERTOFSOLVER_HEADER_INCLUDED
+
+#include <opm/flowdiagnostics/FlowDiagnosticsTool.hpp>
+#include <opm/flowdiagnostics/reorder/tarjan.h>
+#include <opm/flowdiagnostics/utility/AssembledConnections.hpp>
+#include <cassert>
+#include <iostream>
+
+namespace Opm
+{
+
+    class TracerTofSolver
+    {
+    public:
+        TracerTofSolver(const ConnectivityGraph& graph,
+                        const std::vector<double>& pore_volumes,
+                        const ConnectionValues& flux)
+            : g_(graph),
+              pv_(pore_volumes),
+              flux_(flux)
+        {
+        }
+
+        std::vector<double> solveGlobal(const std::vector<CellSet>& all_startsets)
+        {
+            static_cast<void>(all_startsets);
+            computeOrdering();
+            const int num_components = component_starts_.size() - 1;
+            for (int comp = 0; comp < num_components; ++comp) {
+                const int comp_size = component_starts_[comp + 1] - component_starts_[comp];
+                if (comp_size == 1) {
+                    solveSingleCell(sequence_[component_starts_[comp]]);
+                } else {
+                    solveMultiCell(comp_size, &sequence_[component_starts_[comp]]);
+                }
+            }
+            return std::vector<double>(pv_.size(), 0.0);
+        }
+
+        struct LocalSolution {
+            CellSetValues tof;
+            CellSetValues concentration;
+        };
+
+        LocalSolution solveLocal(const CellSet& startset)
+        {
+            static_cast<void>(startset);
+            static_cast<void>(g_);
+            static_cast<void>(flux_);
+            return LocalSolution{ CellSetValues{}, CellSetValues{} };
+        }
+
+    private:
+        void computeOrdering()
+        {
+            // Create the data structure needed for Tarjan's algorithm.
+            const size_t num_cells = g_.numCells();
+            const size_t num_connections = g_.numConnections();
+            Utility::AssembledConnections ac;
+            for (size_t conn_idx = 0; conn_idx < num_connections; ++conn_idx) {
+                auto cells = g_.connection(conn_idx);
+                const double connection_flux = flux_(ConnectionValues::ConnID{conn_idx},
+                                                     ConnectionValues::PhaseID{0});
+                if (connection_flux > 0.0) {
+                    ac.addConnection(cells.first, cells.second, connection_flux);
+                } else {
+                    ac.addConnection(cells.second, cells.first, -connection_flux);
+                }
+            }
+            ac.compress();
+
+            // We might have to pad the start pointers if the last
+            // cell(s) did not have outgoing fluxes, to get the
+            // traditional format expected by tarjan().
+            auto sp = ac.startPointers();
+            if (sp.size() != num_cells + 1) {
+                assert(sp.size() < num_cells + 1);
+                sp.insert(sp.end(), num_cells + 1 - sp.size(), sp.back());
+            }
+            assert(sp.size() == num_cells + 1);
+
+            // Compute topological ordering.
+            struct Deleter { void operator()(TarjanSCCResult* x) { destroy_tarjan_sccresult(x); } };
+            std::unique_ptr<TarjanSCCResult, Deleter> result(tarjan(num_cells, sp.data(), ac.neighbourhood().data()));
+
+            // Extract data from solution.
+            sequence_.resize(num_cells);
+            const int num_comp = tarjan_get_numcomponents(result.get());
+            component_starts_.resize(num_comp + 1);
+            component_starts_[0] = 0;
+            for (int comp = 0; comp < num_comp; ++comp) {
+                const TarjanComponent tc = tarjan_get_strongcomponent(result.get(), comp);
+                std::copy(tc.vertex, tc.vertex + tc.size, sequence_.begin() + component_starts_[comp]);
+                component_starts_[comp + 1] = component_starts_[comp] + tc.size;
+            }
+            assert(component_starts_.back() == int(num_cells));
+        }
+
+        void solveSingleCell(const int cell)
+        {
+            static_cast<void>(cell);
+#if 0
+            // Compute flux terms.
+            // Sources have zero tof, and therefore do not contribute
+            // to upwind_term. Sinks on the other hand, must be added
+            // to the downwind_flux (note sign change resulting from
+            // different sign conventions: pos. source is injection,
+            // pos. flux is outflow).
+            double upwind_term = 0.0;
+            double downwind_flux = std::max(-source_[cell], 0.0);
+            for (int i = grid_.cell_facepos[cell]; i < grid_.cell_facepos[cell+1]; ++i) {
+                int f = grid_.cell_faces[i];
+                double flux;
+                int other;
+                // Compute cell flux
+                if (cell == grid_.face_cells[2*f]) {
+                    flux  = darcyflux_[f];
+                    other = grid_.face_cells[2*f+1];
+                } else {
+                    flux  =-darcyflux_[f];
+                    other = grid_.face_cells[2*f];
+                }
+                // Add flux to upwind_term or downwind_flux
+                if (flux < 0.0) {
+                    // Using tof == 0 on inflow, so we only add a
+                    // nonzero contribution if we are on an internal
+                    // face.
+                    if (other != -1) {
+                        upwind_term += flux*tof_[other];
+                    }
+                } else {
+                    downwind_flux += flux;
+                }
+            }
+
+            // Compute tof.
+            tof_[cell] = (porevolume_[cell] - upwind_term)/downwind_flux;
+#endif
+        }
+
+
+        void solveMultiCell(const int size, const int* cells)
+        {
+            static_cast<void>(size);
+            static_cast<void>(cells);
+        }
+
+        const ConnectivityGraph& g_;
+        const std::vector<double>& pv_;
+        const ConnectionValues& flux_;
+        std::vector<int> sequence_;
+        std::vector<int> component_starts_;
+    };
+
+} // namespace Opm
+
+#endif // OPM_TRACERTOFSOLVER_HEADER_INCLUDED

--- a/tests/test_flowdiagnosticstool.cpp
+++ b/tests/test_flowdiagnosticstool.cpp
@@ -274,6 +274,29 @@ BOOST_AUTO_TEST_CASE (InjectionDiagnostics)
 
 
 
+namespace {
+
+    template <class Collection1, class Collection2>
+    void check_is_close(const Collection1& c1, const Collection2& c2)
+    {
+        BOOST_REQUIRE_EQUAL(c1.size(), c2.size());
+
+        if (! c1.empty()) {
+            auto i1 = c1.begin(), e1 = c1.end();
+            auto i2 = c2.begin();
+
+            for (; i1 != e1; ++i1, ++i2) {
+                BOOST_CHECK_CLOSE(*i1, *i2, 1.0e-10);
+            }
+        }
+    }
+
+} // Namespace Anonymous
+
+
+
+
+
 
 BOOST_AUTO_TEST_CASE (OneDimCase)
 {
@@ -321,7 +344,7 @@ BOOST_AUTO_TEST_CASE (OneDimCase)
 
         BOOST_REQUIRE_EQUAL(tof.size(), cas.connectivity().numCells());
         std::vector<double> expected = { 0.5, 1.5, 2.5, 3.5, 4.5 };
-        BOOST_CHECK_EQUAL_COLLECTIONS(tof.begin(), tof.end(), expected.begin(), expected.end());
+        check_is_close(tof, expected);
     }
 
     // Verify set of start points.

--- a/tests/test_flowdiagnosticstool.cpp
+++ b/tests/test_flowdiagnosticstool.cpp
@@ -335,8 +335,8 @@ BOOST_AUTO_TEST_CASE (OneDimCase)
         s.insert(cas.connectivity().numCells() - 1);
     }
 
-    const auto fwd = diagTool
-        .computeInjectionDiagnostics(Toolbox::StartCells{start});
+    const auto fwd = diagTool.computeInjectionDiagnostics(Toolbox::StartCells{start});
+    const auto rev = diagTool.computeProductionDiagnostics(Toolbox::StartCells{start});
 
     // Global ToF field (accumulated from all injectors)
     {
@@ -344,6 +344,15 @@ BOOST_AUTO_TEST_CASE (OneDimCase)
 
         BOOST_REQUIRE_EQUAL(tof.size(), cas.connectivity().numCells());
         std::vector<double> expected = { 0.5, 1.5, 2.5, 3.5, 4.5 };
+        check_is_close(tof, expected);
+    }
+
+    // Global ToF field (accumulated from all producers)
+    {
+        const auto tof = rev.fd.timeOfFlight();
+
+        BOOST_REQUIRE_EQUAL(tof.size(), cas.connectivity().numCells());
+        std::vector<double> expected = { 4.5, 3.5, 2.5, 1.5, 0.5 };
         check_is_close(tof, expected);
     }
 

--- a/tests/test_flowdiagnosticstool.cpp
+++ b/tests/test_flowdiagnosticstool.cpp
@@ -300,29 +300,29 @@ namespace {
 
 BOOST_AUTO_TEST_CASE (OneDimCase)
 {
-    using FDT = Opm::FlowDiagnosticsTool;
+    using namespace Opm::FlowDiagnostics;
 
     const auto cas = Setup(5, 1);
     const auto& graph = cas.connectivity();
 
-    FDT diagTool(graph);
+    Toolbox diagTool(graph);
 
-    diagTool.assign(FDT::PoreVolume{ cas.poreVolume() });
-    Opm::ConnectionValues flux(Opm::ConnectionValues::NumConnections{ graph.numConnections() },
-                               Opm::ConnectionValues::NumPhases     { 1 });
+    diagTool.assign(Toolbox::PoreVolume{ cas.poreVolume() });
+    ConnectionValues flux(ConnectionValues::NumConnections{ graph.numConnections() },
+                          ConnectionValues::NumPhases     { 1 });
     const size_t nconn = cas.connectivity().numConnections();
     for (size_t conn = 0; conn < nconn; ++conn) {
-        flux(Opm::ConnectionValues::ConnID{conn}, Opm::ConnectionValues::PhaseID{0}) = 0.3;
+        flux(ConnectionValues::ConnID{conn}, ConnectionValues::PhaseID{0}) = 0.3;
     }
-    diagTool.assign(FDT::ConnectionFlux{ flux });
+    diagTool.assign(Toolbox::ConnectionFlux{ flux });
 
-    auto start = std::vector<Opm::CellSet>{};
+    auto start = std::vector<CellSet>{};
     {
         start.emplace_back();
 
         auto& s = start.back();
 
-        s.identify(Opm::CellSetID("I-1"));
+        s.identify(CellSetID("I-1"));
         s.insert(0);
     }
 
@@ -331,12 +331,12 @@ BOOST_AUTO_TEST_CASE (OneDimCase)
 
         auto& s = start.back();
 
-        s.identify(Opm::CellSetID("I-2"));
+        s.identify(CellSetID("I-2"));
         s.insert(cas.connectivity().numCells() - 1);
     }
 
     const auto fwd = diagTool
-        .computeInjectionDiagnostics(FDT::StartCells{start});
+        .computeInjectionDiagnostics(Toolbox::StartCells{start});
 
     // Global ToF field (accumulated from all injectors)
     {
@@ -356,7 +356,7 @@ BOOST_AUTO_TEST_CASE (OneDimCase)
         for (const auto& pt : startpts) {
             auto pos =
                 std::find_if(start.begin(), start.end(),
-                    [&pt](const Opm::CellSet& s)
+                    [&pt](const CellSet& s)
                     {
                         return s.id().to_string() == pt.to_string();
                     });
@@ -369,7 +369,7 @@ BOOST_AUTO_TEST_CASE (OneDimCase)
     // Tracer-ToF
     {
         const auto tof = fwd.fd
-            .timeOfFlight(Opm::CellSetID("I-1"));
+            .timeOfFlight(CellSetID("I-1"));
 
         for (decltype(tof.cellValueCount())
                  i = 0, n = tof.cellValueCount();
@@ -386,7 +386,7 @@ BOOST_AUTO_TEST_CASE (OneDimCase)
     // Tracer Concentration
     {
         const auto conc = fwd.fd
-            .concentration(Opm::CellSetID("I-2"));
+            .concentration(CellSetID("I-2"));
 
         BOOST_TEST_MESSAGE("conc.cellValueCount() = " <<
                            conc.cellValueCount());


### PR DESCRIPTION
This is a first version of the solver class that should be able to compute time-of-flight. It is now used by the Toolbox instead of the mock data. Known limitations:
- does not compute tracer solutions,
- solveLocal() not implemented.
