### PR TITLE
Toolbox: Add move constructor and assignment operator

### DIFF
--- a/opm/flowdiagnostics/Toolbox.cpp
+++ b/opm/flowdiagnostics/Toolbox.cpp
@@ -380,6 +380,19 @@ Toolbox(const ConnectivityGraph& conn)
 Toolbox::~Toolbox()
 {}
 
+Toolbox::Toolbox(Toolbox&& rhs)
+    : pImpl_(std::move(rhs.pImpl_))
+{
+}
+
+Toolbox&
+Toolbox::operator=(Toolbox&& rhs)
+{
+    pImpl_ = std::move(rhs.pImpl_);
+
+    return *this;
+}
+
 Toolbox&
 Toolbox::assign(const PoreVolume& pv)
 {

--- a/opm/flowdiagnostics/Toolbox.hpp
+++ b/opm/flowdiagnostics/Toolbox.hpp
@@ -87,6 +87,9 @@ namespace FlowDiagnostics
 
         ~Toolbox();
 
+        Toolbox(Toolbox&& rhs);
+        Toolbox& operator=(Toolbox&& rhs);
+
         struct PoreVolume
         {
             const std::vector<double>& data;


### PR DESCRIPTION
This enables returning a `Toolbox` from an initialisation function (e.g., a factory-style free function).
