### PR TITLE
TracerToFSolver: Include <algorithm> for std::max()

### DIFF
--- a/opm/flowdiagnostics/TracerTofSolver.cpp
+++ b/opm/flowdiagnostics/TracerTofSolver.cpp
@@ -24,6 +24,7 @@
 
 #include <opm/flowdiagnostics/TracerTofSolver.hpp>
 #include <opm/utility/graph/tarjan.h>
+#include <algorithm>
 #include <cassert>
 #include <cmath>
 #include <memory>


### PR DESCRIPTION
Needed to restore build on VS 2015.U3 (MSVC 19.00.24213.1).
