### PR TITLE
Add assignInflowFlux() to toolbox interface

### DIFF
--- a/opm/flowdiagnostics/Toolbox.cpp
+++ b/opm/flowdiagnostics/Toolbox.cpp
@@ -56,6 +56,7 @@ public:
 
     void assignPoreVolume(const std::vector<double>& pvol);
     void assignConnectionFlux(const ConnectionValues& flux);
+    void assignInflowFlux(const CellSetValues& inflow_flux);
 
     Forward injDiag (const std::vector<CellSet>& start_sets);
     Reverse prodDiag(const std::vector<CellSet>& start_sets);
@@ -65,6 +66,7 @@ private:
 
     std::vector<double> pvol_;
     ConnectionValues    flux_;
+    CellSetValues       inflow_flux_;
 
     AssembledConnections inj_conn_;
     AssembledConnections prod_conn_;
@@ -101,6 +103,12 @@ Toolbox::Impl::assignConnectionFlux(const ConnectionValues& flux)
 
     flux_ = flux;
     conn_built_ = false;
+}
+
+void
+Toolbox::Impl::assignInflowFlux(const CellSetValues& inflow_flux)
+{
+    inflow_flux_ = inflow_flux;
 }
 
 Toolbox::Forward
@@ -231,6 +239,12 @@ void
 Toolbox::assignConnectionFlux(const ConnectionValues& flux)
 {
     pImpl_->assignConnectionFlux(flux);
+}
+
+void
+Toolbox::assignInflowFlux(const CellSetValues& inflow_flux)
+{
+    pImpl_->assignInflowFlux(inflow_flux);
 }
 
 Toolbox::Forward

--- a/opm/flowdiagnostics/Toolbox.cpp
+++ b/opm/flowdiagnostics/Toolbox.cpp
@@ -80,6 +80,7 @@ Toolbox::Impl::Impl(ConnectivityGraph g)
     , pvol_()
     , flux_(ConnectionValues::NumConnections{ 0 },
             ConnectionValues::NumPhases     { 0 })
+    , inflow_flux_()
 {}
 
 void

--- a/opm/flowdiagnostics/Toolbox.hpp
+++ b/opm/flowdiagnostics/Toolbox.hpp
@@ -57,6 +57,9 @@ namespace FlowDiagnostics
         /// Assign fluxes associated with each connection.
         void assignConnectionFlux(const ConnectionValues& flux);
 
+        /// Assign inflow fluxes, typically from wells.
+        void assignInflowFlux(const CellSetValues& inflow_flux);
+
         struct Forward
         {
             const Solution fd;


### PR DESCRIPTION
Not used yet by solver, but proposed now so we can discuss the interface if necessary.

One detail: I have not updated the requirements (in either docs or code) for calling the diagnostics functions, meaning it is ok to call them without assigning an inflow flux. Open to discussing this.
