### PR TITLE
Use source term in time of flight solver, add local solver

### DIFF
--- a/opm/flowdiagnostics/Toolbox.cpp
+++ b/opm/flowdiagnostics/Toolbox.cpp
@@ -66,7 +66,8 @@ private:
 
     std::vector<double> pvol_;
     ConnectionValues    flux_;
-    CellSetValues       inflow_flux_;
+    CellSetValues       only_inflow_flux_;
+    CellSetValues       only_outflow_flux_;
 
     AssembledConnections inj_conn_;
     AssembledConnections prod_conn_;
@@ -80,7 +81,8 @@ Toolbox::Impl::Impl(ConnectivityGraph g)
     , pvol_()
     , flux_(ConnectionValues::NumConnections{ 0 },
             ConnectionValues::NumPhases     { 0 })
-    , inflow_flux_()
+    , only_inflow_flux_()
+    , only_outflow_flux_()
 {}
 
 void
@@ -109,7 +111,28 @@ Toolbox::Impl::assignConnectionFlux(const ConnectionValues& flux)
 void
 Toolbox::Impl::assignInflowFlux(const CellSetValues& inflow_flux)
 {
-    inflow_flux_ = inflow_flux;
+    // Count the inflow (>0) fluxes.
+    const int num_items = inflow_flux.cellValueCount();
+    int num_inflows = 0;
+    for (int item = 0; item < num_items; ++item) {
+        if (inflow_flux.cellValue(item).second > 0.0) {
+            ++num_inflows;
+        }
+    }
+
+    // Reserve memory.
+    only_inflow_flux_ = CellSetValues(num_inflows);
+    only_outflow_flux_ = CellSetValues(num_items - num_inflows);
+
+    // Build in- and out-flow structures.
+    for (int item = 0; item < num_items; ++item) {
+        auto data = inflow_flux.cellValue(item);
+        if (data.second > 0.0) {
+            only_inflow_flux_.addCellValue(data.first, data.second);
+        } else {
+            only_outflow_flux_.addCellValue(data.first, data.second);
+        }
+    }
 }
 
 Toolbox::Forward
@@ -128,7 +151,7 @@ Toolbox::Impl::injDiag(const std::vector<CellSet>& start_sets)
     using ToF = Solution::TimeOfFlight;
     using Conc = Solution::TracerConcentration;
 
-    TracerTofSolver solver(inj_conn_, pvol_);
+    TracerTofSolver solver(inj_conn_, pvol_, only_inflow_flux_);
     sol.assignGlobalToF(solver.solveGlobal(start_sets));
 
     for (const auto& start : start_sets) {
@@ -156,7 +179,7 @@ Toolbox::Impl::prodDiag(const std::vector<CellSet>& start_sets)
     using ToF = Solution::TimeOfFlight;
     using Conc = Solution::TracerConcentration;
 
-    TracerTofSolver solver(prod_conn_, pvol_);
+    TracerTofSolver solver(prod_conn_, pvol_, only_outflow_flux_);
     sol.assignGlobalToF(solver.solveGlobal(start_sets));
 
     for (const auto& start : start_sets) {

--- a/opm/flowdiagnostics/Toolbox.cpp
+++ b/opm/flowdiagnostics/Toolbox.cpp
@@ -130,7 +130,7 @@ Toolbox::Impl::assignInflowFlux(const CellSetValues& inflow_flux)
         if (data.second > 0.0) {
             only_inflow_flux_.addCellValue(data.first, data.second);
         } else {
-            only_outflow_flux_.addCellValue(data.first, data.second);
+            only_outflow_flux_.addCellValue(data.first, -data.second);
         }
     }
 }

--- a/opm/flowdiagnostics/Toolbox.hpp
+++ b/opm/flowdiagnostics/Toolbox.hpp
@@ -58,6 +58,10 @@ namespace FlowDiagnostics
         void assignConnectionFlux(const ConnectionValues& flux);
 
         /// Assign inflow fluxes, typically from wells.
+        ///
+        /// Inflow fluxes (injection) should be positive, outflow
+        /// fluxes (production) should be negative, both should be
+        /// given in the inflow_flux argument passed to this method.
         void assignInflowFlux(const CellSetValues& inflow_flux);
 
         struct Forward

--- a/opm/flowdiagnostics/TracerTofSolver.cpp
+++ b/opm/flowdiagnostics/TracerTofSolver.cpp
@@ -38,6 +38,7 @@ namespace FlowDiagnostics
 
 
 
+    // This computes both in and outflux with a single traversal of the graph.
     struct TracerTofSolver::InOutFluxComputer
     {
         InOutFluxComputer(const AssembledConnections& graph)
@@ -72,6 +73,8 @@ namespace FlowDiagnostics
 
 
 
+    // The InOutFluxComputer is used so that influx_ and outflux_ can be
+    // const members of the class.
     TracerTofSolver::TracerTofSolver(const AssembledConnections& graph,
                                      const std::vector<double>& pore_volumes,
                                      InOutFluxComputer&& inout)

--- a/opm/flowdiagnostics/TracerTofSolver.cpp
+++ b/opm/flowdiagnostics/TracerTofSolver.cpp
@@ -91,10 +91,11 @@ namespace FlowDiagnostics
 
     std::vector<double> TracerTofSolver::solveGlobal(const std::vector<CellSet>& all_startsets)
     {
-        static_cast<void>(all_startsets); // TODO: use to compute tracer.
-
-        // Reset solver variables.
+        // Reset solver variables and set source terms.
         prepareForSolve();
+        for (const CellSet& startset : all_startsets) {
+            setupSourceTerms(startset);
+        }
 
         // Compute topological ordering.
         computeOrdering();
@@ -120,8 +121,9 @@ namespace FlowDiagnostics
 
     TracerTofSolver::LocalSolution TracerTofSolver::solveLocal(const CellSet& startset)
     {
-        // Reset solver variables.
+        // Reset solver variables and set source terms.
         prepareForSolve();
+        setupSourceTerms(startset);
 
         // Compute topological ordering.
         computeLocalOrdering(startset);
@@ -155,6 +157,8 @@ namespace FlowDiagnostics
     {
         // Reset instance variables.
         const int num_cells = pv_.size();
+        source_term_.clear();
+        source_term_.resize(num_cells, 0.0);
         upwind_contrib_.clear();
         upwind_contrib_.resize(num_cells, 0.0);
         tof_.clear();
@@ -162,6 +166,17 @@ namespace FlowDiagnostics
         num_multicell_ = 0;
         max_size_multicell_ = 0;
         max_iter_multicell_ = 0;
+    }
+
+
+
+
+
+    void TracerTofSolver::setupSourceTerms(const CellSet& startset)
+    {
+        for (const int cell : startset) {
+            source_term_[cell] = outflux_[cell] - influx_[cell];
+        }
     }
 
 

--- a/opm/flowdiagnostics/TracerTofSolver.cpp
+++ b/opm/flowdiagnostics/TracerTofSolver.cpp
@@ -38,47 +38,47 @@ namespace FlowDiagnostics
 
 
 
-    namespace {
-
-        std::vector<double> computeInflux(const AssembledConnections& graph)
+    struct TracerTofSolver::InOutFluxComputer
+    {
+        InOutFluxComputer(const AssembledConnections& graph)
         {
             const int num_cells = graph.numRows();
-            std::vector<double> influx(num_cells, 0.0);
+            influx.resize(num_cells, 0.0);
+            outflux.resize(num_cells, 0.0);
             for (int cell = 0; cell < num_cells; ++cell) {
                 const auto nb = graph.cellNeighbourhood(cell);
                 for (const auto& conn : nb) {
                     influx[conn.neighbour] += conn.weight;
-                }
-            }
-            return influx;
-        }
-
-
-
-        std::vector<double> computeOutflux(const AssembledConnections& graph)
-        {
-            const int num_cells = graph.numRows();
-            std::vector<double> outflux(num_cells, 0.0);
-            for (int cell = 0; cell < num_cells; ++cell) {
-                const auto nb = graph.cellNeighbourhood(cell);
-                for (const auto& conn : nb) {
                     outflux[cell] += conn.weight;
                 }
             }
-            return outflux;
         }
 
-    } // anonymous namespace
+        std::vector<double> influx;
+        std::vector<double> outflux;
+    };
+
 
 
 
 
     TracerTofSolver::TracerTofSolver(const AssembledConnections& graph,
                                      const std::vector<double>& pore_volumes)
+        : TracerTofSolver(graph, pore_volumes, InOutFluxComputer(graph))
+    {
+    }
+
+
+
+
+
+    TracerTofSolver::TracerTofSolver(const AssembledConnections& graph,
+                                     const std::vector<double>& pore_volumes,
+                                     InOutFluxComputer&& inout)
         : g_(graph)
         , pv_(pore_volumes)
-        , influx_(computeInflux(graph))
-        , outflux_(computeOutflux(graph))
+        , influx_(std::move(inout.influx))
+        , outflux_(std::move(inout.outflux))
     {
     }
 

--- a/opm/flowdiagnostics/TracerTofSolver.hpp
+++ b/opm/flowdiagnostics/TracerTofSolver.hpp
@@ -77,9 +77,10 @@ namespace FlowDiagnostics
 
         const AssembledConnections& g_;
         const std::vector<double>& pv_;
+        const std::vector<double> influx_;
+        const std::vector<double> outflux_;
         std::vector<int> sequence_;
         std::vector<int> component_starts_;
-        std::vector<double> upwind_influx_;
         std::vector<double> upwind_contrib_;
         std::vector<double> tof_;
         int num_multicell_ = 0;

--- a/opm/flowdiagnostics/TracerTofSolver.hpp
+++ b/opm/flowdiagnostics/TracerTofSolver.hpp
@@ -79,6 +79,7 @@ namespace FlowDiagnostics
         const std::vector<double>& pv_;
         const std::vector<double> influx_;
         const std::vector<double> outflux_;
+        std::vector<double> source_term_;
         std::vector<int> sequence_;
         std::vector<int> component_starts_;
         std::vector<double> upwind_contrib_;
@@ -99,6 +100,8 @@ namespace FlowDiagnostics
                         InOutFluxComputer&& inout);
 
         void prepareForSolve();
+
+        void setupSourceTerms(const CellSet& startset);
 
         void computeOrdering();
 

--- a/opm/flowdiagnostics/TracerTofSolver.hpp
+++ b/opm/flowdiagnostics/TracerTofSolver.hpp
@@ -49,9 +49,10 @@ namespace FlowDiagnostics
     public:
         /// Initialize solver with a given flow graph (a weighted,
         /// directed asyclic graph) containing the out-fluxes from
-        /// each cell, and pore volumes.
+        /// each cell, pore volumes and inflow sources (positive).
         TracerTofSolver(const AssembledConnections& graph,
-                        const std::vector<double>& pore_volumes);
+                        const std::vector<double>& pore_volumes,
+                        const CellSetValues& source_inflow);
 
         /// Compute the global (combining all sources) time-of-flight of each cell.
         ///
@@ -97,6 +98,7 @@ namespace FlowDiagnostics
 
         TracerTofSolver(const AssembledConnections& graph,
                         const std::vector<double>& pore_volumes,
+                        const CellSetValues& source_inflow,
                         InOutFluxComputer&& inout);
 
         void prepareForSolve();

--- a/opm/flowdiagnostics/TracerTofSolver.hpp
+++ b/opm/flowdiagnostics/TracerTofSolver.hpp
@@ -107,6 +107,8 @@ namespace FlowDiagnostics
 
         void computeLocalOrdering(const CellSet& startset);
 
+        void solve();
+
         void solveSingleCell(const int cell);
 
         void solveMultiCell(const int num_cells, const int* cells);

--- a/opm/flowdiagnostics/TracerTofSolver.hpp
+++ b/opm/flowdiagnostics/TracerTofSolver.hpp
@@ -89,7 +89,11 @@ namespace FlowDiagnostics
 
         // --------------  Private methods --------------
 
+        void prepareForSolve();
+
         void computeOrdering();
+
+        void computeLocalOrdering(const CellSet& startset);
 
         void solveSingleCell(const int cell);
 

--- a/opm/flowdiagnostics/TracerTofSolver.hpp
+++ b/opm/flowdiagnostics/TracerTofSolver.hpp
@@ -81,6 +81,7 @@ namespace FlowDiagnostics
         const std::vector<double> influx_;
         const std::vector<double> outflux_;
         std::vector<double> source_term_;
+        std::vector<char> is_start_; // char to avoid the nasty vector<bool> specialization
         std::vector<int> sequence_;
         std::vector<int> component_starts_;
         std::vector<double> upwind_contrib_;
@@ -103,7 +104,7 @@ namespace FlowDiagnostics
 
         void prepareForSolve();
 
-        void setupSourceTerms(const CellSet& startset);
+        void setupStartArray(const CellSet& startset);
 
         void computeOrdering();
 

--- a/opm/flowdiagnostics/TracerTofSolver.hpp
+++ b/opm/flowdiagnostics/TracerTofSolver.hpp
@@ -88,7 +88,15 @@ namespace FlowDiagnostics
         int max_iter_multicell_ = 0;
         const double gauss_seidel_tol_ = 1e-3;
 
+        // --------------  Private helper class --------------
+
+        struct InOutFluxComputer;
+
         // --------------  Private methods --------------
+
+        TracerTofSolver(const AssembledConnections& graph,
+                        const std::vector<double>& pore_volumes,
+                        InOutFluxComputer&& inout);
 
         void prepareForSolve();
 

--- a/tests/test_flowdiagnosticstool.cpp
+++ b/tests/test_flowdiagnosticstool.cpp
@@ -310,23 +310,23 @@ BOOST_AUTO_TEST_CASE (OneDimCase)
     diagTool.assignConnectionFlux(flux);
 
     auto start = std::vector<CellSet>{};
-    {
-        start.emplace_back();
+    // {
+    //     start.emplace_back();
 
-        auto& s = start.back();
+    //     auto& s = start.back();
 
-        s.identify(CellSetID("I-1"));
-        s.insert(0);
-    }
+    //     s.identify(CellSetID("I-1"));
+    //     s.insert(0);
+    // }
 
-    {
-        start.emplace_back();
+    // {
+    //     start.emplace_back();
 
-        auto& s = start.back();
+    //     auto& s = start.back();
 
-        s.identify(CellSetID("I-2"));
-        s.insert(cas.connectivity().numCells() - 1);
-    }
+    //     s.identify(CellSetID("I-2"));
+    //     s.insert(cas.connectivity().numCells() - 1);
+    // }
 
     const auto fwd = diagTool.computeInjectionDiagnostics(start);
     const auto rev = diagTool.computeProductionDiagnostics(start);
@@ -336,7 +336,7 @@ BOOST_AUTO_TEST_CASE (OneDimCase)
         const auto tof = fwd.fd.timeOfFlight();
 
         BOOST_REQUIRE_EQUAL(tof.size(), cas.connectivity().numCells());
-        std::vector<double> expected = { 0.5, 1.5, 2.5, 3.5, 4.5 };
+        std::vector<double> expected = { 0.0, 1.0, 2.0, 3.0, 4.0 };
         check_is_close(tof, expected);
     }
 
@@ -345,7 +345,7 @@ BOOST_AUTO_TEST_CASE (OneDimCase)
         const auto tof = rev.fd.timeOfFlight();
 
         BOOST_REQUIRE_EQUAL(tof.size(), cas.connectivity().numCells());
-        std::vector<double> expected = { 4.5, 3.5, 2.5, 1.5, 0.5 };
+        std::vector<double> expected = { 4.0, 3.0, 2.0, 1.0, 0.0 };
         check_is_close(tof, expected);
     }
 
@@ -371,7 +371,7 @@ BOOST_AUTO_TEST_CASE (OneDimCase)
     // Tracer-ToF
     {
         const auto tof = fwd.fd
-            .timeOfFlight(CellSetID("I-1"));
+            .timeOfFlight(CellSetID("I-2"));
 
         for (decltype(tof.cellValueCount())
                  i = 0, n = tof.cellValueCount();


### PR DESCRIPTION
With this, we get the same global TOF solution as the MRST code (1e-15 relative error) on the SIMPLE.DATA testcase.

The local solver has no direct MRST equivalent.
