### PR TITLE
Refine time-of-flight solver behaviour.

### DIFF
--- a/opm/flowdiagnostics/TracerTofSolver.cpp
+++ b/opm/flowdiagnostics/TracerTofSolver.cpp
@@ -276,16 +276,16 @@ namespace FlowDiagnostics
         if (source == 0.0 && is_start_[cell]) {
             source = std::numeric_limits<double>::infinity(); // Gives 0 tof in start cell.
         }
-        const double total_influx_ = influx_[cell] + source;
+        const double total_influx = influx_[cell] + source;
 
         // Compute effective pv (dividend of tof expression).
         const double eff_pv = pv_[cell] + upwind_contrib_[cell];
 
         // Compute (capped) tof.
-        if (total_influx_ < eff_pv / max_tof_) {
+        if (total_influx < eff_pv / max_tof_) {
             tof_[cell] = max_tof_;
         } else {
-            tof_[cell] = eff_pv / total_influx_;
+            tof_[cell] = eff_pv / total_influx;
         }
 
         // Set contribution for my downwind cells (if any).

--- a/opm/flowdiagnostics/TracerTofSolver.hpp
+++ b/opm/flowdiagnostics/TracerTofSolver.hpp
@@ -90,6 +90,7 @@ namespace FlowDiagnostics
         int max_size_multicell_ = 0;
         int max_iter_multicell_ = 0;
         const double gauss_seidel_tol_ = 1e-3;
+        const double max_tof_ = 200.0 * 365.0 * 24.0 * 60.0 * 60.0; // 200 years.
 
         // --------------  Private helper class --------------
 

--- a/tests/test_flowdiagnosticstool.cpp
+++ b/tests/test_flowdiagnosticstool.cpp
@@ -344,7 +344,7 @@ BOOST_AUTO_TEST_CASE (OneDimCase)
         const auto tof = fwd.fd.timeOfFlight();
 
         BOOST_REQUIRE_EQUAL(tof.size(), cas.connectivity().numCells());
-        std::vector<double> expected = { 0.5, 1.5, 2.5, 3.5, 4.5 };
+        std::vector<double> expected = { 0.5, 1.5, 2.5, 3.5, 0.0 };
         check_is_close(tof, expected);
     }
 
@@ -353,7 +353,7 @@ BOOST_AUTO_TEST_CASE (OneDimCase)
         const auto tof = rev.fd.timeOfFlight();
 
         BOOST_REQUIRE_EQUAL(tof.size(), cas.connectivity().numCells());
-        std::vector<double> expected = { 4.5, 3.5, 2.5, 1.5, 0.5 };
+        std::vector<double> expected = { 0.0, 3.5, 2.5, 1.5, 0.5 };
         check_is_close(tof, expected);
     }
 


### PR DESCRIPTION
Also, fix error in implementation of zero time-of-flight for source-less start cells, including amending the test to check for correctness.
