### PR TITLE
Fix multi-cell solve and make max tof work like in MRST.

### DIFF
--- a/opm/flowdiagnostics/TracerTofSolver.hpp
+++ b/opm/flowdiagnostics/TracerTofSolver.hpp
@@ -49,8 +49,10 @@ namespace FlowDiagnostics
     public:
         /// Initialize solver with a given flow graph (a weighted,
         /// directed asyclic graph) containing the out-fluxes from
-        /// each cell, pore volumes and inflow sources (positive).
+        /// each cell, the reverse graph (with in-fluxes from each
+        /// cell), pore volumes and inflow sources (positive).
         TracerTofSolver(const AssembledConnections& graph,
+                        const AssembledConnections& reverse_graph,
                         const std::vector<double>& pore_volumes,
                         const CellSetValues& source_inflow);
 
@@ -77,6 +79,7 @@ namespace FlowDiagnostics
         // --------------  Private data members --------------
 
         const AssembledConnections& g_;
+        const AssembledConnections& g_reverse_;
         const std::vector<double>& pv_;
         const std::vector<double> influx_;
         const std::vector<double> outflux_;
@@ -84,7 +87,6 @@ namespace FlowDiagnostics
         std::vector<char> is_start_; // char to avoid the nasty vector<bool> specialization
         std::vector<int> sequence_;
         std::vector<int> component_starts_;
-        std::vector<double> upwind_contrib_;
         std::vector<double> tof_;
         int num_multicell_ = 0;
         int max_size_multicell_ = 0;
@@ -99,6 +101,7 @@ namespace FlowDiagnostics
         // --------------  Private methods --------------
 
         TracerTofSolver(const AssembledConnections& graph,
+                        const AssembledConnections& reverse_graph,
                         const std::vector<double>& pore_volumes,
                         const CellSetValues& source_inflow,
                         InOutFluxComputer&& inout);


### PR DESCRIPTION
A bug was discovered with multi-cell solves: writing to the
upwind_contrib_ for downstream cells during a multi-cell solve
was wrong, and not easy to fix. The approach used was changed so
that upwind contribution was computed before computing tof in
solveSingleCell(), instead of written to after computing tod.
The new approach is also simpler, not requiring a member array
for the upwind contributions.

Treatment of maximum time-of-flight has changed to match MRSTs
somewhat convoluted approach: first cap only when local inflow
fill time is above the max, post-process to cap every cell after
the solution step proper (done in solve()).

With this change and PR OPM/opm-flowdiagnostics-applications#15 we reproduce the MRST solution for the Norne testcase, at least for investigated timesteps: December 1 1997 (step 2) and April 1 2001 (step 100).

Other than that, the PRs are independent.
