### PR TITLE
Use fill time (not half fill time) for source cell tofs.

### DIFF
--- a/opm/flowdiagnostics/TracerTofSolver.cpp
+++ b/opm/flowdiagnostics/TracerTofSolver.cpp
@@ -278,7 +278,7 @@ namespace FlowDiagnostics
     void TracerTofSolver::solveSingleCell(const int cell)
     {
         // Compute influx (divisor of tof expression).
-        double source = 2.0 * source_term_[cell];  // Initial tof for well cell equal to half fill time.
+        double source = source_term_[cell];  // Initial tof for well cell equal to fill time.
         if (source == 0.0 && is_start_[cell]) {
             source = std::numeric_limits<double>::infinity(); // Gives 0 tof in start cell.
         }

--- a/tests/test_flowdiagnosticstool.cpp
+++ b/tests/test_flowdiagnosticstool.cpp
@@ -344,7 +344,7 @@ BOOST_AUTO_TEST_CASE (OneDimCase)
         const auto tof = fwd.fd.timeOfFlight();
 
         BOOST_REQUIRE_EQUAL(tof.size(), cas.connectivity().numCells());
-        std::vector<double> expected = { 0.5, 1.5, 2.5, 3.5, 0.0 };
+        std::vector<double> expected = { 1.0, 2.0, 3.0, 4.0, 0.0 };
         check_is_close(tof, expected);
     }
 
@@ -353,7 +353,7 @@ BOOST_AUTO_TEST_CASE (OneDimCase)
         const auto tof = rev.fd.timeOfFlight();
 
         BOOST_REQUIRE_EQUAL(tof.size(), cas.connectivity().numCells());
-        std::vector<double> expected = { 0.0, 3.5, 2.5, 1.5, 0.5 };
+        std::vector<double> expected = { 0.0, 4.0, 3.0, 2.0, 1.0 };
         check_is_close(tof, expected);
     }
 


### PR DESCRIPTION
With this, the solutions produced are once more in sync with MRST on the SIMPLE and Norne cases we use for verification.

Even though it changes the solution in every cell, I still consider this a minor change. I will therefore self-merge it.
