### PR TITLE
Fix local solve

### DIFF
--- a/opm/flowdiagnostics/Toolbox.cpp
+++ b/opm/flowdiagnostics/Toolbox.cpp
@@ -139,7 +139,7 @@ Toolbox::Impl::injDiag(const std::vector<CellSet>& start_sets)
     using Conc = Solution::TracerConcentration;
 
     TracerTofSolver solver(downstream_conn_, upstream_conn_, pvol_, only_inflow_flux_);
-    sol.assignGlobalToF(solver.solveGlobal(start_sets));
+    sol.assignGlobalToF(solver.solveGlobal());
 
     for (const auto& start : start_sets) {
         auto solution = solver.solveLocal(start);
@@ -167,7 +167,7 @@ Toolbox::Impl::prodDiag(const std::vector<CellSet>& start_sets)
     using Conc = Solution::TracerConcentration;
 
     TracerTofSolver solver(upstream_conn_, downstream_conn_, pvol_, only_outflow_flux_);
-    sol.assignGlobalToF(solver.solveGlobal(start_sets));
+    sol.assignGlobalToF(solver.solveGlobal());
 
     for (const auto& start : start_sets) {
         auto solution = solver.solveLocal(start);

--- a/opm/flowdiagnostics/Toolbox.cpp
+++ b/opm/flowdiagnostics/Toolbox.cpp
@@ -198,7 +198,7 @@ Toolbox::Impl::buildAssembledConnections()
         if (connection_flux > 0.0) {
             downstream_conn_.addConnection(cells.first, cells.second, connection_flux);
             upstream_conn_.addConnection(cells.second, cells.first, connection_flux);
-        } else {
+        } else if (connection_flux < 0.0) {
             downstream_conn_.addConnection(cells.second, cells.first, -connection_flux);
             upstream_conn_.addConnection(cells.first, cells.second, -connection_flux);
         }

--- a/opm/flowdiagnostics/TracerTofSolver.cpp
+++ b/opm/flowdiagnostics/TracerTofSolver.cpp
@@ -305,13 +305,14 @@ namespace FlowDiagnostics
         for (const auto& conn : g_reverse_.cellNeighbourhood(cell)) {
             const int upwind_cell = conn.neighbour;
             const double flux = conn.weight;
-            upwind_tof_contrib += tof_[upwind_cell] * flux;
+            upwind_tof_contrib += tof_[upwind_cell] * (tracer_[upwind_cell] != 0.0 ? tracer_[upwind_cell] : 1.0) * flux;
             upwind_tracer_contrib += tracer_[upwind_cell] * flux;
         }
 
         // Compute time-of-flight and tracer.
-        tof_[cell] = (pv_[cell] + upwind_tof_contrib) / total_influx;
         tracer_[cell] = is_start_[cell] ? 1.0 : upwind_tracer_contrib / total_influx;
+        const double tracer = tracer_[cell] != 0.0 ? tracer_[cell] : 1.0;
+        tof_[cell] = (pv_[cell]*tracer + upwind_tof_contrib) / (total_influx*tracer);
     }
 
 

--- a/opm/flowdiagnostics/TracerTofSolver.cpp
+++ b/opm/flowdiagnostics/TracerTofSolver.cpp
@@ -239,7 +239,7 @@ namespace FlowDiagnostics
         }
 
         // Extract data from solution.
-        sequence_.resize(num_cells);
+        sequence_.resize(num_cells); // For local solutions this is the upper limit of the size. TODO: use exact size.
         const int num_comp = tarjan_get_numcomponents(result.get());
         component_starts_.resize(num_comp + 1);
         component_starts_[0] = 0;

--- a/opm/flowdiagnostics/TracerTofSolver.hpp
+++ b/opm/flowdiagnostics/TracerTofSolver.hpp
@@ -59,7 +59,7 @@ namespace FlowDiagnostics
         /// Compute the global (combining all sources) time-of-flight of each cell.
         ///
         /// TODO: also compute tracer solution.
-        std::vector<double> solveGlobal(const std::vector<CellSet>& all_startsets);
+        std::vector<double> solveGlobal();
 
         /// Output data struct for solveLocal().
         struct LocalSolution {
@@ -110,6 +110,8 @@ namespace FlowDiagnostics
         void prepareForSolve();
 
         void setupStartArray(const CellSet& startset);
+
+        void setupStartArrayFromSource();
 
         void computeOrdering();
 

--- a/tests/test_flowdiagnosticstool.cpp
+++ b/tests/test_flowdiagnosticstool.cpp
@@ -40,7 +40,6 @@
 #include <opm/utility/numeric/RandomVector.hpp>
 
 #include <algorithm>
-#include <iostream>
 
 using namespace Opm::FlowDiagnostics;
 
@@ -299,7 +298,7 @@ BOOST_AUTO_TEST_CASE (OneDimCase)
         const auto tof = fwd.fd.timeOfFlight();
 
         BOOST_REQUIRE_EQUAL(tof.size(), cas.connectivity().numCells());
-        std::vector<double> expected = { 1.0, 2.0, 3.0, 4.0, 0.0 };
+        std::vector<double> expected = { 1.0, 2.0, 3.0, 4.0, 5.0 };
         check_is_close(tof, expected);
     }
 
@@ -308,7 +307,7 @@ BOOST_AUTO_TEST_CASE (OneDimCase)
         const auto tof = rev.fd.timeOfFlight();
 
         BOOST_REQUIRE_EQUAL(tof.size(), cas.connectivity().numCells());
-        std::vector<double> expected = { 0.0, 4.0, 3.0, 2.0, 1.0 };
+        std::vector<double> expected = { 5.0, 4.0, 3.0, 2.0, 1.0 };
         check_is_close(tof, expected);
     }
 
@@ -499,10 +498,13 @@ BOOST_AUTO_TEST_CASE (LocalSolutions)
     // Create fluxes.
     ConnectionValues flux(ConnectionValues::NumConnections{ graph.numConnections() },
                           ConnectionValues::NumPhases     { 1 });
-    // const size_t nconn = cas.connectivity().numConnections();
-    // for (size_t conn = 0; conn < nconn; ++conn) {
-    //     std::cout << graph.connection(conn).first << ' ' << graph.connection(conn).second << std::endl;
-    // }
+    const size_t nconn = cas.connectivity().numConnections();
+    for (size_t conn = 0; conn < nconn; ++conn) {
+        BOOST_TEST_MESSAGE("Connection " << conn << " connects cells "
+                           << graph.connection(conn).first << " and "
+                           << graph.connection(conn).second);
+    }
+
     using C = ConnectionValues::ConnID;
     using P = ConnectionValues::PhaseID;
     flux(C{0}, P{0}) = 0.3;
@@ -532,8 +534,6 @@ BOOST_AUTO_TEST_CASE (LocalSolutions)
     {
         const auto tof = fwd.fd.timeOfFlight();
 
-        // for (const auto t : tof) { std::cout << " " << t; }; std::cout << std::endl;
-
         BOOST_REQUIRE_EQUAL(tof.size(), cas.connectivity().numCells());
         std::vector<double> expected = { 1.0, 2.0, 3.0, 1.0, 2.0, 2.5 };
         check_is_close(tof, expected);
@@ -542,8 +542,6 @@ BOOST_AUTO_TEST_CASE (LocalSolutions)
     // Global ToF field (accumulated from all producers)
     {
         const auto tof = rev.fd.timeOfFlight();
-
-        // for (const auto t : tof) { std::cout << " " << t; }; std::cout << std::endl;
 
         BOOST_REQUIRE_EQUAL(tof.size(), cas.connectivity().numCells());
         std::vector<double> expected = { 3.5, 2.5, 0.5, 2.5, 1.5, 1.0 };

--- a/tests/test_flowdiagnosticstool.cpp
+++ b/tests/test_flowdiagnosticstool.cpp
@@ -587,20 +587,20 @@ BOOST_AUTO_TEST_CASE (LocalSolutions)
         }
     }
 
-    // // Local I-1 tof.
-    // {
-    //     const auto tof = fwd.fd.timeOfFlight(CellSetID("I-1"));
-    //     std::vector<std::pair<int, double>> expected = { {0, 1.0}, {1, 2.0}, {2, 3.5}, {4, 2.5}, {5, 3.0} };
-    //     BOOST_REQUIRE_EQUAL(tof.size(), expected.size());
+    // Local I-1 tof.
+    {
+        const auto tof = fwd.fd.timeOfFlight(CellSetID("I-1"));
+        std::vector<std::pair<int, double>> expected = { {0, 1.0}, {1, 2.0}, {2, 3.5}, {4, 2.5}, {5, 3.0} };
+        BOOST_REQUIRE_EQUAL(tof.size(), expected.size());
 
-    //     int i = 0;
-    //     for (const auto& v : tof) {
-    //         BOOST_TEST_MESSAGE("ToF[" << v.first << "] = " << v.second);
-    //         BOOST_CHECK_EQUAL(v.first, expected[i].first);
-    //         BOOST_CHECK_CLOSE(v.second, expected[i].second, 1.0e-10);
-    //         ++i;
-    //     }
-    // }
+        int i = 0;
+        for (const auto& v : tof) {
+            BOOST_TEST_MESSAGE("ToF[" << v.first << "] = " << v.second);
+            BOOST_CHECK_EQUAL(v.first, expected[i].first);
+            BOOST_CHECK_CLOSE(v.second, expected[i].second, 1.0e-10);
+            ++i;
+        }
+    }
 
     // Local I-2 tracer concentration.
     {
@@ -617,20 +617,20 @@ BOOST_AUTO_TEST_CASE (LocalSolutions)
         }
     }
 
-    // // Local I-2 tof.
-    // {
-    //     const auto tof = fwd.fd.timeOfFlight(CellSetID("I-2"));
-    //     std::vector<std::pair<int, double>> expected = { {2, 2.5}, {3, 1.0}, {4, 1.5}, {5, 2.0} };
-    //     BOOST_REQUIRE_EQUAL(tof.size(), expected.size());
+    // Local I-2 tof.
+    {
+        const auto tof = fwd.fd.timeOfFlight(CellSetID("I-2"));
+        std::vector<std::pair<int, double>> expected = { {2, 2.5}, {3, 1.0}, {4, 1.5}, {5, 2.0} };
+        BOOST_REQUIRE_EQUAL(tof.size(), expected.size());
 
-    //     int i = 0;
-    //     for (const auto& v : tof) {
-    //         BOOST_TEST_MESSAGE("ToF[" << v.first << "] = " << v.second);
-    //         BOOST_CHECK_EQUAL(v.first, expected[i].first);
-    //         BOOST_CHECK_CLOSE(v.second, expected[i].second, 1.0e-10);
-    //         ++i;
-    //     }
-    // }
+        int i = 0;
+        for (const auto& v : tof) {
+            BOOST_TEST_MESSAGE("ToF[" << v.first << "] = " << v.second);
+            BOOST_CHECK_EQUAL(v.first, expected[i].first);
+            BOOST_CHECK_CLOSE(v.second, expected[i].second, 1.0e-10);
+            ++i;
+        }
+    }
 
 }
 

--- a/tests/test_flowdiagnosticstool.cpp
+++ b/tests/test_flowdiagnosticstool.cpp
@@ -565,7 +565,7 @@ BOOST_AUTO_TEST_CASE (LocalSolutions)
                                         {
                                             return s.id().to_string() == pt.to_string();
                                         });
-                BOOST_CHECK(pos != injstart.end());
+                BOOST_CHECK(pos != s1.end());
             }
         }
     }

--- a/tests/test_flowdiagnosticstool.cpp
+++ b/tests/test_flowdiagnosticstool.cpp
@@ -40,6 +40,7 @@
 #include <opm/utility/numeric/RandomVector.hpp>
 
 #include <algorithm>
+#include <iostream>
 
 using namespace Opm::FlowDiagnostics;
 
@@ -438,5 +439,200 @@ BOOST_AUTO_TEST_CASE (OneDimCase)
     }
 
 }
+
+// Arrows indicate a flux of 0.3, O is a source of 0.3
+// and X is a sink of 0.3 (each cell has a pore volume of 0.3).
+//  ----------------------------
+//  |       |        |         |
+//  |   O   ->       ->        |
+//  |       |        ->        |
+//  |       |        |    ||   |
+//  -------------^--------VV----
+//  |       |    |   |         |
+//  |       |        |         |
+//  |   O   ->       |   XX    |
+//  |       |        |         |
+//  ----------------------------
+// Cell indices:
+//  ----------------------------
+//  |       |        |         |
+//  |       |        |         |
+//  |   3   |    4   |    5    |
+//  |       |        |         |
+//  ----------------------------
+//  |       |        |         |
+//  |       |        |         |
+//  |   0   |    1   |    2    |
+//  |       |        |         |
+//  ----------------------------
+// Expected global injection TOF:
+//  ----------------------------
+//  |       |        |         |
+//  |       |        |         |
+//  |   1.0 |    2.0 |    2.5  |
+//  |       |        |         |
+//  ----------------------------
+//  |       |        |         |
+//  |       |        |         |
+//  |   1.0 |    2.0 |    3.0  |
+//  |       |        |         |
+//  ----------------------------
+// Expected global production TOF:
+//  ----------------------------
+//  |       |        |         |
+//  |       |        |         |
+//  |   2.5 |    1.5 |    1.0  |
+//  |       |        |         |
+//  ----------------------------
+//  |       |        |         |
+//  |       |        |         |
+//  |   3.5 |    2.5 |    0.5  |
+//  |       |        |         |
+//  ----------------------------
+BOOST_AUTO_TEST_CASE (LocalSolutions)
+{
+    using namespace Opm::FlowDiagnostics;
+
+    const auto cas = Setup(3, 2);
+    const auto& graph = cas.connectivity();
+
+    // Create fluxes.
+    ConnectionValues flux(ConnectionValues::NumConnections{ graph.numConnections() },
+                          ConnectionValues::NumPhases     { 1 });
+    // const size_t nconn = cas.connectivity().numConnections();
+    // for (size_t conn = 0; conn < nconn; ++conn) {
+    //     std::cout << graph.connection(conn).first << ' ' << graph.connection(conn).second << std::endl;
+    // }
+    using C = ConnectionValues::ConnID;
+    using P = ConnectionValues::PhaseID;
+    flux(C{0}, P{0}) = 0.3;
+    flux(C{1}, P{0}) = 0.0;
+    flux(C{2}, P{0}) = 0.3;
+    flux(C{3}, P{0}) = 0.6;
+    flux(C{4}, P{0}) = 0.0;
+    flux(C{5}, P{0}) = 0.3;
+    flux(C{6}, P{0}) = -0.6;
+
+    // Create well in/out flows.
+    CellSetValues wellflow = { {0, 0.3}, {3, 0.3}, {2, -0.6} };
+
+    Toolbox diagTool(graph);
+    diagTool.assignPoreVolume(cas.poreVolume());
+    diagTool.assignConnectionFlux(flux);
+    diagTool.assignInflowFlux(wellflow);
+
+    auto injstart = std::vector<CellSet>{ CellSet(CellSetID("I-1"), {0}),
+                                          CellSet(CellSetID("I-2"), {3}) };
+    auto prdstart = std::vector<CellSet>{ CellSet(CellSetID("P-1"), {2}) };
+
+    const auto fwd = diagTool.computeInjectionDiagnostics(injstart);
+    const auto rev = diagTool.computeProductionDiagnostics(prdstart);
+
+    // Global ToF field (accumulated from all injectors)
+    {
+        const auto tof = fwd.fd.timeOfFlight();
+
+        // for (const auto t : tof) { std::cout << " " << t; }; std::cout << std::endl;
+
+        BOOST_REQUIRE_EQUAL(tof.size(), cas.connectivity().numCells());
+        std::vector<double> expected = { 1.0, 2.0, 3.0, 1.0, 2.0, 2.5 };
+        check_is_close(tof, expected);
+    }
+
+    // Global ToF field (accumulated from all producers)
+    {
+        const auto tof = rev.fd.timeOfFlight();
+
+        // for (const auto t : tof) { std::cout << " " << t; }; std::cout << std::endl;
+
+        BOOST_REQUIRE_EQUAL(tof.size(), cas.connectivity().numCells());
+        std::vector<double> expected = { 3.5, 2.5, 0.5, 2.5, 1.5, 1.0 };
+        check_is_close(tof, expected);
+    }
+
+    // Verify set of start points.
+    {
+        using VCS = std::vector<Opm::FlowDiagnostics::CellSet>;
+        using VCSI = std::vector<Opm::FlowDiagnostics::CellSetID>;
+        using P = std::pair<VCS, VCSI>;
+        std::vector<P> pairs { P{ injstart, fwd.fd.startPoints() }, P{ prdstart, rev.fd.startPoints() } };
+        for (const auto& p : pairs) {
+            const auto& s1 = p.first;
+            const auto& s2 = p.second;
+            BOOST_CHECK_EQUAL(s1.size(), s2.size());
+            for (const auto& pt : s2) {
+                // ID of 'pt' *MUST* be in set of identified start points.
+                auto pos = std::find_if(s1.begin(), s1.end(),
+                                        [&pt](const CellSet& s)
+                                        {
+                                            return s.id().to_string() == pt.to_string();
+                                        });
+                BOOST_CHECK(pos != injstart.end());
+            }
+        }
+    }
+
+    // Local I-1 tracer concentration.
+    {
+        const auto conc = fwd.fd.concentration(CellSetID("I-1"));
+        std::vector<std::pair<int, double>> expected = { {0, 1.0}, {1, 1.0}, {2, 0.5}, {4, 0.5}, {5, 0.5} };
+        BOOST_REQUIRE_EQUAL(conc.size(), expected.size());
+
+        int i = 0;
+        for (const auto& v : conc) {
+            BOOST_TEST_MESSAGE("Conc[" << v.first << "] = " << v.second);
+            BOOST_CHECK_EQUAL(v.first, expected[i].first);
+            BOOST_CHECK_CLOSE(v.second, expected[i].second, 1.0e-10);
+            ++i;
+        }
+    }
+
+    // // Local I-1 tof.
+    // {
+    //     const auto tof = fwd.fd.timeOfFlight(CellSetID("I-1"));
+    //     std::vector<std::pair<int, double>> expected = { {0, 1.0}, {1, 2.0}, {2, 3.5}, {4, 2.5}, {5, 3.0} };
+    //     BOOST_REQUIRE_EQUAL(tof.size(), expected.size());
+
+    //     int i = 0;
+    //     for (const auto& v : tof) {
+    //         BOOST_TEST_MESSAGE("ToF[" << v.first << "] = " << v.second);
+    //         BOOST_CHECK_EQUAL(v.first, expected[i].first);
+    //         BOOST_CHECK_CLOSE(v.second, expected[i].second, 1.0e-10);
+    //         ++i;
+    //     }
+    // }
+
+    // Local I-2 tracer concentration.
+    {
+        const auto conc = fwd.fd.concentration(CellSetID("I-2"));
+        std::vector<std::pair<int, double>> expected = { {2, 0.5}, {3, 1.0}, {4, 0.5}, {5, 0.5} };
+        BOOST_REQUIRE_EQUAL(conc.size(), expected.size());
+
+        int i = 0;
+        for (const auto& v : conc) {
+            BOOST_TEST_MESSAGE("Conc[" << v.first << "] = " << v.second);
+            BOOST_CHECK_EQUAL(v.first, expected[i].first);
+            BOOST_CHECK_CLOSE(v.second, expected[i].second, 1.0e-10);
+            ++i;
+        }
+    }
+
+    // // Local I-2 tof.
+    // {
+    //     const auto tof = fwd.fd.timeOfFlight(CellSetID("I-2"));
+    //     std::vector<std::pair<int, double>> expected = { {2, 2.5}, {3, 1.0}, {4, 1.5}, {5, 2.0} };
+    //     BOOST_REQUIRE_EQUAL(tof.size(), expected.size());
+
+    //     int i = 0;
+    //     for (const auto& v : tof) {
+    //         BOOST_TEST_MESSAGE("ToF[" << v.first << "] = " << v.second);
+    //         BOOST_CHECK_EQUAL(v.first, expected[i].first);
+    //         BOOST_CHECK_CLOSE(v.second, expected[i].second, 1.0e-10);
+    //         ++i;
+    //     }
+    // }
+
+}
+
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This fixes behaviour for local solves. It combines two separate fixes:
 - ensure zero-flux connections are not included
 - take tracer < 1 into account for time-of-flight.