### PR TITLE
Add Measure of Resilience to Local ToF Calculations

### DIFF
--- a/opm/flowdiagnostics/TracerTofSolver.cpp
+++ b/opm/flowdiagnostics/TracerTofSolver.cpp
@@ -323,7 +323,14 @@ namespace FlowDiagnostics
 
         // Compute time-of-flight and tracer.
         tracer_[cell] = is_start_[cell] ? 1.0 : upwind_tracer_contrib / total_influx;
-        tof_[cell] = (pv_[cell]*tracer_[cell] + upwind_tof_contrib) / (total_influx*tracer_[cell]);
+
+        if (tracer_[cell] > 0.0) {
+            tof_[cell] = (pv_[cell]*tracer_[cell] + upwind_tof_contrib)
+                       / (total_influx * tracer_[cell]);
+        }
+        else {
+            tof_[cell] = max_tof_;
+        }
     }
 
 


### PR DESCRIPTION
In particular, guard against all upstream neighbours of a cell having too little inflow to get a well-defined tracer value.  In the case of a local solve--meaning we cover only those cells that are downstream from a particular set of starting points--it is possible that all of a cell's upstream neighbours are either unreachable or get treated to the "little inflow" early return from `solveSingleCell()`. In this case, both `upwind_tof_contrib` and `upwind_tracer_contrib` become zero, and the subsequent ToF calculation leads to a 0/0 arithmetic operation which generates a `NaN` value that propagates to its downstream neighbours and contaminates the overall numerical solution.

Guard against this situation by explictily checking that the cell's tracer value is positive before attempting the division.  We arbitrarily assign maximum time-of-flight to cells that get zero tracer concentrations in this fashion.

This patch solves (or at least works around) the Issue reported in OPM/ResInsight#1117, but does not solve the other issue brought forth in an e-mail from the ResInsight developers--namely that the sum of all concentration values in a cell could go as high as the total number of tracers (i.e., all tracers have concentration one) in some cases.