### PR TITLE
Add overload and test for flowCapacityStorageCapacityCurve().

### DIFF
--- a/opm/flowdiagnostics/DerivedQuantities.cpp
+++ b/opm/flowdiagnostics/DerivedQuantities.cpp
@@ -70,9 +70,26 @@ namespace FlowDiagnostics
                                            const Toolbox::Reverse& producer_solution,
                                            const std::vector<double>& pv)
     {
-        const auto& ftof = injector_solution.fd.timeOfFlight();
-        const auto& rtof = producer_solution.fd.timeOfFlight();
-        if (pv.size() != ftof.size() || pv.size() != rtof.size()) {
+        return flowCapacityStorageCapacityCurve(injector_solution.fd.timeOfFlight(),
+                                                producer_solution.fd.timeOfFlight(),
+                                                pv);
+    }
+
+
+
+
+    /// The F-Phi curve.
+    ///
+    /// The F-Phi curve is an analogue to the fractional flow
+    /// curve in a 1D displacement. It can be used to compute
+    /// other interesting diagnostic quantities such as the Lorenz
+    /// coefficient. For a technical description see Shavali et
+    /// al. (SPE 146446), Shook and Mitchell (SPE 124625).
+    Graph flowCapacityStorageCapacityCurve(const std::vector<double>& injector_tof,
+                                           const std::vector<double>& producer_tof,
+                                           const std::vector<double>& pv)
+    {
+        if (pv.size() != injector_tof.size() || pv.size() != producer_tof.size()) {
             throw std::runtime_error("flowCapacityStorageCapacityCurve(): "
                                      "Input solutions must have same size.");
         }
@@ -82,7 +99,7 @@ namespace FlowDiagnostics
         typedef std::pair<double, double> D2;
         std::vector<D2> time_and_pv(n);
         for (int ii = 0; ii < n; ++ii) {
-            time_and_pv[ii].first = ftof[ii] + rtof[ii]; // Total travel time.
+            time_and_pv[ii].first = injector_tof[ii] + producer_tof[ii]; // Total travel time.
             time_and_pv[ii].second = pv[ii];
         }
         std::sort(time_and_pv.begin(), time_and_pv.end());

--- a/opm/flowdiagnostics/DerivedQuantities.hpp
+++ b/opm/flowdiagnostics/DerivedQuantities.hpp
@@ -50,6 +50,14 @@ namespace FlowDiagnostics
                                            const Toolbox::Reverse& producer_solution,
                                            const std::vector<double>& pore_volume);
 
+    /// This overload gets the injector and producer time-of-flight
+    /// directly instead of extracting it from the solution
+    /// objects. It otherwise behaves identically to the other
+    /// overload.
+    Graph flowCapacityStorageCapacityCurve(const std::vector<double>& injector_tof,
+                                           const std::vector<double>& producer_tof,
+                                           const std::vector<double>& pore_volume);
+
     /// The Lorenz coefficient from the F-Phi curve.
     ///
     /// The Lorenz coefficient is a measure of heterogeneity. It

--- a/tests/test_derivedquantities.cpp
+++ b/tests/test_derivedquantities.cpp
@@ -247,6 +247,8 @@ BOOST_AUTO_TEST_CASE (OneDimCase)
         BOOST_CHECK_THROW(flowCapacityStorageCapacityCurve(fwd, rev, {}), std::runtime_error);
         const auto fcapscap = flowCapacityStorageCapacityCurve(fwd, rev, pv);
         check_is_close(fcapscap, expectedFPhi);
+        const auto fcapscap2 = flowCapacityStorageCapacityCurve(fwd.fd.timeOfFlight(), rev.fd.timeOfFlight(), pv);
+        check_is_close(fcapscap2, expectedFPhi);
 
         BOOST_TEST_MESSAGE("==== Lorenz coefficient");
         const double expectedLorenz = 0.0;
@@ -295,5 +297,29 @@ BOOST_AUTO_TEST_CASE (OneDimCase)
     }
 
 }
+
+
+
+
+
+BOOST_AUTO_TEST_CASE (GeneralCase)
+{
+    BOOST_TEST_MESSAGE("==== F-Phi graph");
+
+    std::vector<double> pv { 1.0, 2.0, 1.0 };
+    std::vector<double> ftof { 0.0, 2.0, 1.0 };
+    std::vector<double> rtof { 1.0, 2.0, 0.0 };
+    const Graph expectedFPhi{
+        { 0.0, 0.25, 0.5, 1.0 },
+        { 0.0, 0.4, 0.8, 1.0 }
+    };
+    const auto fcapscap = flowCapacityStorageCapacityCurve(ftof, rtof, pv);
+    check_is_close(fcapscap, expectedFPhi);
+
+    BOOST_TEST_MESSAGE("==== Lorenz coefficient");
+    const double expectedLorenz = 0.3;
+    BOOST_CHECK_CLOSE(lorenzCoefficient(fcapscap), expectedLorenz, 1e-10);
+}
+
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This allows users to more directly obtain the graph from arbitrary in-data. The user is then responsible for ensuring the input data are reasonable.

Also added a test for this code. The new test fails for the bug fixed in #30, which should ensure that bug stays fixed.