### PR TITLE
Fix zero tracer

### DIFF
--- a/opm/flowdiagnostics/TracerTofSolver.cpp
+++ b/opm/flowdiagnostics/TracerTofSolver.cpp
@@ -251,7 +251,7 @@ namespace FlowDiagnostics
         }
 
         // Extract data from solution.
-        sequence_.resize(num_cells); // For local solutions this is the upper limit of the size. TODO: use exact size.
+        sequence_.resize(num_cells); // For local solutions this is the upper limit of the size. Will give proper size afterwards.
         const int num_comp = tarjan_get_numcomponents(result.get());
         component_starts_.resize(num_comp + 1);
         component_starts_[0] = 0;
@@ -260,6 +260,7 @@ namespace FlowDiagnostics
             std::copy(tc.vertex, tc.vertex + tc.size, sequence_.begin() + component_starts_[comp]);
             component_starts_[comp + 1] = component_starts_[comp] + tc.size;
         }
+        sequence_.resize(component_starts_.back());
     }
 
 


### PR DESCRIPTION
With this, it should not be possible to get zero tracer value in reachable cells, for a local solve (the solver will throw std::logic_error should it happen). For a global solve, the tarjan() call will visit all cells, even completely isolated ones, these may still get zero tracer value (as they should).