### PR TITLE
Handle multiple perforations for same cell

### DIFF
--- a/opm/flowdiagnostics/DerivedQuantities.hpp
+++ b/opm/flowdiagnostics/DerivedQuantities.hpp
@@ -110,9 +110,9 @@ namespace FlowDiagnostics
     std::pair<double, double>
     injectorProducerPairFlux(const Toolbox::Forward& injector_solution,
                              const Toolbox::Reverse& producer_solution,
-                             const CellSet& injector_cells,
-                             const CellSet& producer_cells,
-                             const CellSetValues& inflow_flux);
+                             const CellSetID& injector,
+                             const CellSetID& producer,
+                             const std::map<CellSetID, CellSetValues>& inflow_flux);
 
 
 } // namespace FlowDiagnostics

--- a/opm/flowdiagnostics/Toolbox.cpp
+++ b/opm/flowdiagnostics/Toolbox.cpp
@@ -123,7 +123,7 @@ Toolbox::Impl::assignInflowFlux(const std::map<CellSetID, CellSetValues>& inflow
                 inj_flux_by_id_[id].insert(data);
             } else if (data.second < 0.0) {
                 only_outflow_flux_[data.first] += -data.second;
-                prod_flux_by_id_[id].insert(data);
+                prod_flux_by_id_[id].insert(std::make_pair(data.first, -data.second));
             }
         }
     }

--- a/opm/flowdiagnostics/Toolbox.cpp
+++ b/opm/flowdiagnostics/Toolbox.cpp
@@ -56,7 +56,7 @@ public:
 
     void assignPoreVolume(const std::vector<double>& pvol);
     void assignConnectionFlux(const ConnectionValues& flux);
-    void assignInflowFlux(const CellSetValues& inflow_flux);
+    void assignInflowFlux(const std::map<CellSetID, CellSetValues>& inflow_flux);
 
     Forward injDiag (const std::vector<CellSet>& start_sets);
     Reverse prodDiag(const std::vector<CellSet>& start_sets);
@@ -109,15 +109,17 @@ Toolbox::Impl::assignConnectionFlux(const ConnectionValues& flux)
 }
 
 void
-Toolbox::Impl::assignInflowFlux(const CellSetValues& inflow_flux)
+Toolbox::Impl::assignInflowFlux(const std::map<CellSetID, CellSetValues>& inflow_flux)
 {
     only_inflow_flux_.clear();
     only_outflow_flux_.clear();
-    for (const auto& data : inflow_flux) {
-        if (data.second > 0.0) {
-            only_inflow_flux_[data.first] = data.second;
-        } else if (data.second < 0.0) {
-            only_outflow_flux_[data.first] = -data.second;
+    for (const auto& inflow_set : inflow_flux) {
+        for (const auto& data : inflow_set.second) {
+            if (data.second > 0.0) {
+                only_inflow_flux_[data.first] += data.second;
+            } else if (data.second < 0.0) {
+                only_outflow_flux_[data.first] += -data.second;
+            }
         }
     }
 }
@@ -271,7 +273,7 @@ Toolbox::assignConnectionFlux(const ConnectionValues& flux)
 }
 
 void
-Toolbox::assignInflowFlux(const CellSetValues& inflow_flux)
+Toolbox::assignInflowFlux(const std::map<CellSetID, CellSetValues>& inflow_flux)
 {
     pImpl_->assignInflowFlux(inflow_flux);
 }

--- a/opm/flowdiagnostics/Toolbox.hpp
+++ b/opm/flowdiagnostics/Toolbox.hpp
@@ -62,7 +62,9 @@ namespace FlowDiagnostics
         /// Inflow fluxes (injection) should be positive, outflow
         /// fluxes (production) should be negative, both should be
         /// given in the inflow_flux argument passed to this method.
-        void assignInflowFlux(const CellSetValues& inflow_flux);
+        /// Values from a single well should typically be associated with
+        /// a single CellSetID and be a single CellSetValues object.
+        void assignInflowFlux(const std::map<CellSetID, CellSetValues>& inflow_flux);
 
         struct Forward
         {

--- a/opm/flowdiagnostics/TracerTofSolver.cpp
+++ b/opm/flowdiagnostics/TracerTofSolver.cpp
@@ -125,7 +125,7 @@ namespace FlowDiagnostics
 
 
 
-    TracerTofSolver::LocalSolution TracerTofSolver::solveLocal(const CellSet& startset)
+    TracerTofSolver::LocalSolution TracerTofSolver::solveLocal(const CellSetValues& startset)
     {
         // Reset solver variables and set source terms.
         prepareForSolve();
@@ -174,9 +174,10 @@ namespace FlowDiagnostics
 
 
 
-    void TracerTofSolver::setupStartArray(const CellSet& startset)
+    void TracerTofSolver::setupStartArray(const CellSetValues& startset)
     {
-        for (const int cell : startset) {
+        for (const auto& startpoint : startset) {
+            const int cell = startpoint.first;
             is_start_[cell] = 1;
         }
     }
@@ -231,10 +232,14 @@ namespace FlowDiagnostics
 
 
 
-    void TracerTofSolver::computeLocalOrdering(const CellSet& startset)
+    void TracerTofSolver::computeLocalOrdering(const CellSetValues& startset)
     {
         // Extract start cells.
-        std::vector<int> startcells(startset.begin(), startset.end());
+        std::vector<int> startcells;
+        startcells.reserve(startset.size());
+        for (const auto& startpoint : startset) {
+            startcells.push_back(startpoint.first);
+        }
 
         // Compute reverse topological ordering.
         const size_t num_cells = pv_.size();

--- a/opm/flowdiagnostics/TracerTofSolver.cpp
+++ b/opm/flowdiagnostics/TracerTofSolver.cpp
@@ -100,6 +100,7 @@ namespace FlowDiagnostics
         , influx_(std::move(inout.influx))
         , outflux_(std::move(inout.outflux))
         , source_term_(expandSparse(pore_volumes.size(), source_inflow))
+        , local_source_term_(pore_volumes.size(), 0.0)
     {
     }
 
@@ -112,10 +113,12 @@ namespace FlowDiagnostics
         // Reset solver variables and set source terms.
         prepareForSolve();
         setupStartArrayFromSource();
+        local_source_term_ = source_term_;
 
         // Compute topological ordering and solve.
         computeOrdering();
         solve();
+        std::fill(local_source_term_.begin(), local_source_term_.end(), 0.0);
 
         // Return computed time-of-flight.
         return tof_;
@@ -133,7 +136,9 @@ namespace FlowDiagnostics
 
         // Compute local topological ordering and solve.
         computeLocalOrdering(startset);
+        setupLocalSource(startset);
         solve();
+        cleanupLocalSource(startset);
 
         // Return computed time-of-flight.
         CellSetValues local_tof;
@@ -276,6 +281,31 @@ namespace FlowDiagnostics
 
 
 
+    void TracerTofSolver::setupLocalSource(const CellSetValues& startset)
+    {
+        for (const auto& startpoint : startset) {
+            if (startpoint.second < 0.0) {
+                throw std::logic_error("Start set for local solve has negative source value.");
+            }
+            local_source_term_[startpoint.first] = startpoint.second;
+        }
+    }
+
+
+
+
+
+    void TracerTofSolver::cleanupLocalSource(const CellSetValues& startset)
+    {
+        for (const auto& startpoint : startset) {
+            local_source_term_[startpoint.first] = 0.0;
+        }
+    }
+
+
+
+
+
     void TracerTofSolver::solve()
     {
         // Solve each component.
@@ -302,7 +332,7 @@ namespace FlowDiagnostics
     void TracerTofSolver::solveSingleCell(const int cell)
     {
         // Compute influx (divisor of tof expression).
-        double source = source_term_[cell];  // Initial tof for well cell equal to fill time.
+        double source = source_term_[cell];
         if (source == 0.0 && is_start_[cell]) {
             source = std::numeric_limits<double>::infinity(); // Gives 0 tof in start cell.
         }
@@ -322,11 +352,7 @@ namespace FlowDiagnostics
             // should get a contribution from the local source term
             // (which is then considered to be containing the
             // currently considered tracer).
-            //
-            // Start cells should therefore never have a zero source
-            // term. This may need to change in the future to support
-            // local tracing from arbitrary locations.
-            upwind_tracer_contrib += source;
+            upwind_tracer_contrib += local_source_term_[cell];
         }
 
         // The following should be true if Tarjan was done correctly.

--- a/opm/flowdiagnostics/TracerTofSolver.hpp
+++ b/opm/flowdiagnostics/TracerTofSolver.hpp
@@ -50,7 +50,9 @@ namespace FlowDiagnostics
         /// Initialize solver with a given flow graph (a weighted,
         /// directed acyclic graph) containing the out-fluxes from
         /// each cell, the reverse graph (with in-fluxes from each
-        /// cell), pore volumes and inflow sources (positive).
+        /// cell), pore volumes and all (positive) inflow sources. If
+        /// there are multiple inflow sources for a single cell, they
+        /// should be added before passing to this function.
         TracerTofSolver(const AssembledConnections& graph,
                         const AssembledConnections& reverse_graph,
                         const std::vector<double>& pore_volumes,
@@ -69,8 +71,10 @@ namespace FlowDiagnostics
 
         /// Compute a local solution tracer and time-of-flight solution.
         ///
-        /// Local means that only cells downwind from he startset are considered.
-        /// The solution is therefore potentially sparse.
+        /// Local means that only cells downwind from he startset are
+        /// considered. The solution is therefore potentially sparse.
+        /// The startset must contain the (positive) source term for
+        /// each start cell.
         LocalSolution solveLocal(const CellSetValues& startset);
 
     private:

--- a/opm/flowdiagnostics/TracerTofSolver.hpp
+++ b/opm/flowdiagnostics/TracerTofSolver.hpp
@@ -48,7 +48,7 @@ namespace FlowDiagnostics
     {
     public:
         /// Initialize solver with a given flow graph (a weighted,
-        /// directed asyclic graph) containing the out-fluxes from
+        /// directed acyclic graph) containing the out-fluxes from
         /// each cell, the reverse graph (with in-fluxes from each
         /// cell), pore volumes and inflow sources (positive).
         TracerTofSolver(const AssembledConnections& graph,
@@ -71,8 +71,7 @@ namespace FlowDiagnostics
         ///
         /// Local means that only cells downwind from he startset are considered.
         /// The solution is therefore potentially sparse.
-        /// TODO: not implemented!
-        LocalSolution solveLocal(const CellSet& startset);
+        LocalSolution solveLocal(const CellSetValues& startset);
 
     private:
 
@@ -110,13 +109,13 @@ namespace FlowDiagnostics
 
         void prepareForSolve();
 
-        void setupStartArray(const CellSet& startset);
+        void setupStartArray(const CellSetValues& startset);
 
         void setupStartArrayFromSource();
 
         void computeOrdering();
 
-        void computeLocalOrdering(const CellSet& startset);
+        void computeLocalOrdering(const CellSetValues& startset);
 
         void solve();
 

--- a/opm/flowdiagnostics/TracerTofSolver.hpp
+++ b/opm/flowdiagnostics/TracerTofSolver.hpp
@@ -73,7 +73,7 @@ namespace FlowDiagnostics
         ///
         /// Local means that only cells downwind from he startset are
         /// considered. The solution is therefore potentially sparse.
-        /// The startset must contain the (positive) source term for
+        /// The startset must contain the (nonnegative) source term for
         /// each start cell.
         LocalSolution solveLocal(const CellSetValues& startset);
 
@@ -87,6 +87,7 @@ namespace FlowDiagnostics
         const std::vector<double> influx_;
         const std::vector<double> outflux_;
         std::vector<double> source_term_;
+        std::vector<double> local_source_term_;
         std::vector<char> is_start_; // char to avoid the nasty vector<bool> specialization
         std::vector<int> sequence_;
         std::vector<int> component_starts_;
@@ -120,6 +121,10 @@ namespace FlowDiagnostics
         void computeOrdering();
 
         void computeLocalOrdering(const CellSetValues& startset);
+
+        void setupLocalSource(const CellSetValues& startset);
+
+        void cleanupLocalSource(const CellSetValues& startset);
 
         void solve();
 

--- a/tests/test_derivedquantities.cpp
+++ b/tests/test_derivedquantities.cpp
@@ -222,7 +222,7 @@ BOOST_AUTO_TEST_CASE (OneDimCase)
     const auto& flux = cas.flux();
 
     // Create well in/out flows.
-    CellSetValues wellflow = { {0, 0.3}, {4, -0.3} };
+    std::map<CellSetID, CellSetValues> wellflow = { { CellSetID("I-1"), {{0, 0.3}} }, { CellSetID("P-1"), {{4, -0.3}} } };
 
     Toolbox diagTool(graph);
     diagTool.assignPoreVolume(pv);
@@ -291,7 +291,7 @@ BOOST_AUTO_TEST_CASE (OneDimCase)
         const double vol12 = injectorProducerPairVolume(fwd, rev, pv, CellSetID("I-1"), CellSetID("P-1"));
         BOOST_CHECK_CLOSE(vol12, expectedVol12, 1e-10);
 
-        const auto pairflux = injectorProducerPairFlux(fwd, rev, inje[0], prod[0], wellflow);
+        const auto pairflux = injectorProducerPairFlux(fwd, rev, CellSetID("I-1"), CellSetID("P-1"), wellflow);
         BOOST_CHECK_CLOSE(pairflux.first, 0.3, 1e-10);
         BOOST_CHECK_CLOSE(pairflux.second, -0.3, 1e-10);
     }

--- a/tests/test_flowdiagnosticstool.cpp
+++ b/tests/test_flowdiagnosticstool.cpp
@@ -216,7 +216,7 @@ BOOST_AUTO_TEST_CASE (OneDimCase)
     }
 
     // Create well in/out flows.
-    CellSetValues wellflow = { {0, 0.3}, {4, -0.3} };
+    std::map<CellSetID, CellSetValues> wellflow = { { CellSetID("I-1"), {{0, 0.3}} }, { CellSetID("P-1"), {{4, -0.3}} } };
 
     Toolbox diagTool(graph);
     diagTool.assignPoreVolume(cas.poreVolume());
@@ -426,7 +426,9 @@ BOOST_AUTO_TEST_CASE (LocalSolutions)
     flux(C{6}, P{0}) = -0.6;
 
     // Create well in/out flows.
-    CellSetValues wellflow = { {0, 0.3}, {3, 0.3}, {2, -0.6} };
+    std::map<CellSetID, CellSetValues> wellflow = { { CellSetID("I-1"), {{0, 0.3}} },
+                                                    { CellSetID("I-2"), {{3, 0.3}} },
+                                                    { CellSetID("P-1"), {{2, -0.6}} } };
 
     Toolbox diagTool(graph);
     diagTool.assignPoreVolume(cas.poreVolume());
@@ -624,7 +626,9 @@ BOOST_AUTO_TEST_CASE (LocalSolutionsWithMidflowSource)
     flux(C{1}, P{0}) = 0.6;
 
     // Create well in/out flows.
-    CellSetValues wellflow = { {0, 0.3}, {1, 0.3}, {2, -0.6} };
+    std::map<CellSetID, CellSetValues> wellflow = { { CellSetID("I-1"), {{0, 0.3}} },
+                                                    { CellSetID("I-2"), {{1, 0.3}} },
+                                                    { CellSetID("P-1"), {{2, -0.6}} } };
 
     Toolbox diagTool(graph);
     diagTool.assignPoreVolume(cas.poreVolume());
@@ -824,7 +828,9 @@ BOOST_AUTO_TEST_CASE (LocalSolutionsPerfSameCell)
     flux(C{0}, P{0}) = 0.6;
 
     // Create well in/out flows.
-    CellSetValues wellflow = { {0, 0.6}, {1, -0.6} };
+    std::map<CellSetID, CellSetValues> wellflow = { { CellSetID("I-1"), {{0, 0.3}} },
+                                                    { CellSetID("I-2"), {{0, 0.3}} },
+                                                    { CellSetID("P-1"), {{1, -0.6}} } };
 
     Toolbox diagTool(graph);
     diagTool.assignPoreVolume(cas.poreVolume());

--- a/tests/test_flowdiagnosticstool.cpp
+++ b/tests/test_flowdiagnosticstool.cpp
@@ -744,4 +744,204 @@ BOOST_AUTO_TEST_CASE (LocalSolutionsWithMidflowSource)
 
 
 
+
+// Arrows indicate a flux of 0.3, O is a source of 0.3
+// and X is a sink of 0.3 (each cell has a pore volume of 0.3).
+//  -----------------------------
+//  |             |             |
+//  |   O     O   ->    XX      |
+//  | "I-1" "I-2" ->   "P-1"    |
+//  |             |             |
+//  -----------------------------
+// Cell indices:
+//  -----------------------------
+//  |             |             |
+//  |             |             |
+//  |      0      |       1     |
+//  |             |             |
+//  -----------------------------
+// Expected global injection TOF:
+//  -----------------------------
+//  |             |             |
+//  |             |             |
+//  |     0.5     |     1.0     |
+//  |             |             |
+//  -----------------------------
+// Expected global production TOF:
+//  -----------------------------
+//  |             |             |
+//  |             |             |
+//  |     1.0     |     0.5     |
+//  |             |             |
+//  -----------------------------
+// Expected local tracer I-1:
+//  -----------------------------
+//  |             |             |
+//  |             |             |
+//  |     0.5     |     0.5     |
+//  |             |             |
+//  -----------------------------
+// Expected local tracer I-2:
+//  -----------------------------
+//  |             |             |
+//  |             |             |
+//  |     0.5     |     0.5     |
+//  |             |             |
+//  -----------------------------
+// Expected local tof I-1:
+//  -----------------------------
+//  |             |             |
+//  |             |             |
+//  |     0.5     |     1.0     |
+//  |             |             |
+//  -----------------------------
+// Expected local tof I-2:
+//  -----------------------------
+//  |             |             |
+//  |             |             |
+//  |     0.5     |     1.0     |
+//  |             |             |
+//  -----------------------------
+BOOST_AUTO_TEST_CASE (LocalSolutionsPerfSameCell)
+{
+    BOOST_TEST_MESSAGE("==============   Test: LocalSolutionsPerfSameCell   ==============");
+    using namespace Opm::FlowDiagnostics;
+
+    const auto cas = Setup(2, 1);
+    const auto& graph = cas.connectivity();
+
+    // Create fluxes.
+    ConnectionValues flux(ConnectionValues::NumConnections{ graph.numConnections() },
+                          ConnectionValues::NumPhases     { 1 });
+    const size_t nconn = cas.connectivity().numConnections();
+    for (size_t conn = 0; conn < nconn; ++conn) {
+        BOOST_TEST_MESSAGE("Connection " << conn << " connects cells "
+                           << graph.connection(conn).first << " and "
+                           << graph.connection(conn).second);
+    }
+    using C = ConnectionValues::ConnID;
+    using P = ConnectionValues::PhaseID;
+    flux(C{0}, P{0}) = 0.6;
+
+    // Create well in/out flows.
+    CellSetValues wellflow = { {0, 0.6}, {1, -0.6} };
+
+    Toolbox diagTool(graph);
+    diagTool.assignPoreVolume(cas.poreVolume());
+    diagTool.assignConnectionFlux(flux);
+    diagTool.assignInflowFlux(wellflow);
+
+    auto injstart = std::vector<CellSet>{ CellSet(CellSetID("I-1"), {0}),
+                                          CellSet(CellSetID("I-2"), {0}) };
+    auto prdstart = std::vector<CellSet>{ CellSet(CellSetID("P-1"), {1}) };
+
+    const auto fwd = diagTool.computeInjectionDiagnostics(injstart);
+    const auto rev = diagTool.computeProductionDiagnostics(prdstart);
+    // Global ToF field (accumulated from all injectors)
+    {
+        BOOST_TEST_MESSAGE("== Global injector ToF");
+        const auto tof = fwd.fd.timeOfFlight();
+        BOOST_REQUIRE_EQUAL(tof.size(), cas.connectivity().numCells());
+        std::vector<double> expected = { 0.5, 1.0 };
+        check_is_close(tof, expected);
+    }
+
+    // Global ToF field (accumulated from all producers)
+    {
+        BOOST_TEST_MESSAGE("== Global producer ToF");
+        const auto tof = rev.fd.timeOfFlight();
+        BOOST_REQUIRE_EQUAL(tof.size(), cas.connectivity().numCells());
+        std::vector<double> expected = { 1.0, 0.5 };
+        check_is_close(tof, expected);
+    }
+
+    // Verify set of start points.
+    {
+        using VCS = std::vector<Opm::FlowDiagnostics::CellSet>;
+        using VCSI = std::vector<Opm::FlowDiagnostics::CellSetID>;
+        using P = std::pair<VCS, VCSI>;
+        std::vector<P> pairs { P{ injstart, fwd.fd.startPoints() }, P{ prdstart, rev.fd.startPoints() } };
+        for (const auto& p : pairs) {
+            const auto& s1 = p.first;
+            const auto& s2 = p.second;
+            BOOST_CHECK_EQUAL(s1.size(), s2.size());
+            for (const auto& pt : s2) {
+                // ID of 'pt' *MUST* be in set of identified start points.
+                auto pos = std::find_if(s1.begin(), s1.end(),
+                                        [&pt](const CellSet& s)
+                                        {
+                                            return s.id().to_string() == pt.to_string();
+                                        });
+                BOOST_CHECK(pos != s1.end());
+            }
+        }
+    }
+
+    // Local I-1 tracer concentration.
+    {
+        BOOST_TEST_MESSAGE("== I-1 tracer");
+        const auto conc = fwd.fd.concentration(CellSetID("I-1"));
+        std::vector<std::pair<int, double>> expected = { {0, 0.5}, {1, 0.5} };
+        BOOST_REQUIRE_EQUAL(conc.size(), expected.size());
+
+        int i = 0;
+        for (const auto& v : conc) {
+            BOOST_TEST_MESSAGE("Conc[" << v.first << "] = " << v.second);
+            BOOST_CHECK_EQUAL(v.first, expected[i].first);
+            BOOST_CHECK_CLOSE(v.second, expected[i].second, 1.0e-10);
+            ++i;
+        }
+    }
+
+    // Local I-1 tof.
+    {
+        BOOST_TEST_MESSAGE("== I-1 tof");
+        const auto tof = fwd.fd.timeOfFlight(CellSetID("I-1"));
+        std::vector<std::pair<int, double>> expected = { {0, 0.5}, {1, 1.0} };
+        BOOST_REQUIRE_EQUAL(tof.size(), expected.size());
+
+        int i = 0;
+        for (const auto& v : tof) {
+            BOOST_TEST_MESSAGE("ToF[" << v.first << "] = " << v.second);
+            BOOST_CHECK_EQUAL(v.first, expected[i].first);
+            BOOST_CHECK_CLOSE(v.second, expected[i].second, 1.0e-10);
+            ++i;
+        }
+    }
+
+    // Local I-2 tracer concentration.
+    {
+        BOOST_TEST_MESSAGE("== I-2 tracer");
+        const auto conc = fwd.fd.concentration(CellSetID("I-2"));
+        std::vector<std::pair<int, double>> expected = { {0, 0.5}, {1, 0.5} };
+        BOOST_REQUIRE_EQUAL(conc.size(), expected.size());
+
+        int i = 0;
+        for (const auto& v : conc) {
+            BOOST_TEST_MESSAGE("Conc[" << v.first << "] = " << v.second);
+            BOOST_CHECK_EQUAL(v.first, expected[i].first);
+            BOOST_CHECK_CLOSE(v.second, expected[i].second, 1.0e-10);
+            ++i;
+        }
+    }
+
+    // Local I-2 tof.
+    {
+        BOOST_TEST_MESSAGE("== I-2 tof");
+        const auto tof = fwd.fd.timeOfFlight(CellSetID("I-2"));
+        std::vector<std::pair<int, double>> expected = { {0, 0.5}, {1, 1.0} };
+        BOOST_REQUIRE_EQUAL(tof.size(), expected.size());
+
+        int i = 0;
+        for (const auto& v : tof) {
+            BOOST_TEST_MESSAGE("ToF[" << v.first << "] = " << v.second);
+            BOOST_CHECK_EQUAL(v.first, expected[i].first);
+            BOOST_CHECK_CLOSE(v.second, expected[i].second, 1.0e-10);
+            ++i;
+        }
+    }
+}
+
+
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_flowdiagnosticstool.cpp
+++ b/tests/test_flowdiagnosticstool.cpp
@@ -228,7 +228,7 @@ BOOST_AUTO_TEST_CASE (OneDimCase)
         const int first_cell = 0;
         const int last_cell = cas.connectivity().numCells() - 1;
         auto start = std::vector<CellSet>{ CellSet(CellSetID("I-1"), {first_cell}),
-                                           CellSet(CellSetID("I-2"), {last_cell}) };
+                                           CellSet(CellSetID("P-1"), {last_cell}) };
         BOOST_CHECK_THROW(diagTool.computeInjectionDiagnostics(start), std::runtime_error);
         BOOST_CHECK_THROW(diagTool.computeProductionDiagnostics(start), std::runtime_error);
     }
@@ -236,7 +236,7 @@ BOOST_AUTO_TEST_CASE (OneDimCase)
     const int first_cell = 0;
     const int last_cell = cas.connectivity().numCells() - 1;
     auto start_fwd = std::vector<CellSet>{ CellSet(CellSetID("I-1"), {first_cell}) };
-    auto start_rev = std::vector<CellSet>{ CellSet(CellSetID("I-2"), {last_cell}) };
+    auto start_rev = std::vector<CellSet>{ CellSet(CellSetID("P-1"), {last_cell}) };
     const auto fwd = diagTool.computeInjectionDiagnostics(start_fwd);
     const auto rev = diagTool.computeProductionDiagnostics(start_rev);
 


### PR DESCRIPTION
With this, we can separate the currently investigated source from the global, sum-of-all-sources. This allows us to track contributions to tracer and tof from separate perforations in the same cell.

The API has changed for Toolbox::assignInflowFlux(): we change from a (cell index -> value) association to a nested (ID -> (cell index -> value)) association.