### PR TITLE
Remove BOOST_TEST_DYN_LINK definitions.

### DIFF
--- a/dune.module
+++ b/dune.module
@@ -5,8 +5,8 @@
 
 Module: opm-flowdiagnostics
 Description: Open Porous Media Initiative flow diagnostics
-Version: 2018.04-pre
-Label: 2018.04-pre
+Version: 2018.10-pre
+Label: 2018.10-pre
 Maintainer: opm@opm-project.org
 MaintainerName: OPM community
 Url: http://opm-project.org

--- a/tests/test_assembledconnections.cpp
+++ b/tests/test_assembledconnections.cpp
@@ -18,13 +18,7 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#if HAVE_CONFIG_H
 #include <config.h>
-#endif // HAVE_CONFIG_H
-
-#if HAVE_DYNAMIC_BOOST_TEST
-#define BOOST_TEST_DYN_LINK
-#endif
 
 #define NVERBOSE
 

--- a/tests/test_cellset.cpp
+++ b/tests/test_cellset.cpp
@@ -20,10 +20,6 @@
 
 #include <config.h>
 
-#if HAVE_DYNAMIC_BOOST_TEST
-#define BOOST_TEST_DYN_LINK
-#endif
-
 #define NVERBOSE
 
 #define BOOST_TEST_MODULE TEST_CELLSET

--- a/tests/test_connectionvalues.cpp
+++ b/tests/test_connectionvalues.cpp
@@ -18,13 +18,7 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#if HAVE_CONFIG_H
 #include <config.h>
-#endif // HAVE_CONFIG_H
-
-#if HAVE_DYNAMIC_BOOST_TEST
-#define BOOST_TEST_DYN_LINK
-#endif
 
 #define NVERBOSE
 

--- a/tests/test_connectivitygraph.cpp
+++ b/tests/test_connectivitygraph.cpp
@@ -18,13 +18,7 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#if HAVE_CONFIG_H
 #include <config.h>
-#endif // HAVE_CONFIG_H
-
-#if HAVE_DYNAMIC_BOOST_TEST
-#define BOOST_TEST_DYN_LINK
-#endif
 
 #define NVERBOSE
 

--- a/tests/test_derivedquantities.cpp
+++ b/tests/test_derivedquantities.cpp
@@ -17,13 +17,7 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#if HAVE_CONFIG_H
 #include <config.h>
-#endif // HAVE_CONFIG_H
-
-#if HAVE_DYNAMIC_BOOST_TEST
-#define BOOST_TEST_DYN_LINK
-#endif // HAVE_DYNAMIC_BOOST_TEST
 
 #define NVERBOSE
 

--- a/tests/test_flowdiagnosticstool.cpp
+++ b/tests/test_flowdiagnosticstool.cpp
@@ -18,13 +18,7 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#if HAVE_CONFIG_H
 #include <config.h>
-#endif // HAVE_CONFIG_H
-
-#if HAVE_DYNAMIC_BOOST_TEST
-#define BOOST_TEST_DYN_LINK
-#endif // HAVE_DYNAMIC_BOOST_TEST
 
 #define NVERBOSE
 

--- a/tests/test_tarjan.cpp
+++ b/tests/test_tarjan.cpp
@@ -20,10 +20,6 @@
 
 #include <config.h>
 
-#if HAVE_DYNAMIC_BOOST_TEST
-#define BOOST_TEST_DYN_LINK
-#endif
-
 #define NVERBOSE
 
 #define BOOST_TEST_MODULE TarjanImplementationTest


### PR DESCRIPTION
Handled by build system now. Also: bump version number.

Will self-merge as trivial.