### PR TITLE
#43 Fix build on Visual Studio 2019

### DIFF
--- a/opm/flowdiagnostics/DerivedQuantities.cpp
+++ b/opm/flowdiagnostics/DerivedQuantities.cpp
@@ -25,6 +25,7 @@
 #include <opm/flowdiagnostics/DerivedQuantities.hpp>
 #include <algorithm>
 #include <numeric>
+#include <stdexcept>
 
 namespace Opm
 {


### PR DESCRIPTION
Adding a missing include which seems to not be a problem for any other compiler than VS 2019.

(but it is universally correct to include it)