### PR TITLE
Make Flow Diagnostics Module Compile w/OPM 2021.04

### DIFF
--- a/dune.module
+++ b/dune.module
@@ -5,8 +5,8 @@
 
 Module: opm-flowdiagnostics
 Description: Open Porous Media Initiative flow diagnostics
-Version: 2020.04-pre
-Label: 2020.04-pre
+Version: 2021.04-pre
+Label: 2021.04-pre
 Maintainer: opm@opm-project.org
 MaintainerName: OPM community
 Url: http://opm-project.org

--- a/opm-flowdiagnostics-prereqs.cmake
+++ b/opm-flowdiagnostics-prereqs.cmake
@@ -10,10 +10,9 @@ set (opm-flowdiagnostics_DEPS
 	# compile with C99 support if available
 	"C99"
 	# compile with C++0x/11 support if available
-	"CXX11Features REQUIRED"
 	"Boost 1.44.0
 		COMPONENTS unit_test_framework REQUIRED"
-  "opm-common REQUIRED"
+	"opm-common REQUIRED"
 	)
 
 find_package_deps(opm-flowdiagnostics)


### PR DESCRIPTION
We must bump the version number and cease using "CXX11Features". The latter is no longer provided (or needed) in opm-common.